### PR TITLE
PILOT-900 Add support for name folders

### DIFF
--- a/app/models/models_items.py
+++ b/app/models/models_items.py
@@ -38,6 +38,7 @@ class GETItemsByLocation(BaseModel):
     recursive: bool
     archived: bool = False
     parent_path: Optional[str]
+    name: Optional[str]
     page_size: int = 10
     page: int = 0
 
@@ -67,6 +68,7 @@ class GETItemResponse(APIResponse):
                 'id': 'dc763d28-7e74-4db3-a702-fa719aa702c6',
                 'extra': {
                     'tags': ['tag1', 'tag2'],
+                    'system_tags': ['tag1', 'tag2'],
                     'attributes': {'101778d7-a628-41ea-823b-e4b377f3476c': {'key1': 'value1', 'key2': 'value2'}},
                 },
             },
@@ -87,6 +89,7 @@ class POSTItem(BaseModel):
     location_uri: str
     version: str
     tags: list[str] = []
+    system_tags: list[str] = []
     attribute_template_id: Optional[UUID]
     attributes: dict = {}
 
@@ -106,6 +109,12 @@ class POSTItem(BaseModel):
     def tags_count(cls, v):
         if len(v) > 10:
             raise ValueError('Maximum of 10 tags')
+        return v
+    
+    @validator('system_tags')
+    def system_tags_count(cls, v):
+        if len(v) > 10:
+            raise ValueError('Maximum of 10 system tags')
         return v
 
     @validator('name')

--- a/app/routers/v1/items/crud.py
+++ b/app/routers/v1/items/crud.py
@@ -132,6 +132,8 @@ def get_items_by_location(params: GETItem, api_response: APIResponse):
             ItemModel.archived == params.archived,
         )
     )
+    if params.name:
+        item_query = item_query.filter(ItemModel.name == encode_label_for_ltree(params.name))
     if params.parent_path:
         regex = f'{encode_path_for_ltree(params.parent_path)}'
         if params.recursive:
@@ -170,6 +172,7 @@ def create_item(data: POSTItem) -> dict:
         'item_id': item.id,
         'extra': {
             'tags': data.tags,
+            'system_tags': data.system_tags,
             'attributes': {str(data.attribute_template_id): data.attributes} if data.attributes else {},
         },
     }
@@ -211,6 +214,7 @@ def update_item(item_id: UUID, data: PUTItem) -> dict:
     extended = db.session.query(ExtendedModel).filter_by(item_id=item_id).first()
     extended.extra = {
         'tags': data.tags,
+        'system_tags': data.system_tags,
         'attributes': {str(data.attribute_template_id): data.attributes} if data.attributes else {},
     }
     db.session.commit()

--- a/app/routers/v1/items/crud.py
+++ b/app/routers/v1/items/crud.py
@@ -150,7 +150,7 @@ def create_item(data: POSTItem) -> dict:
         raise BadRequestException('Attributes do not match attribute template')
     encoded_item_name = encode_label_for_ltree(data.name)
     item_model_data = {
-        'parent': data.parent,
+        'parent': data.parent if data.parent else None,
         'parent_path': Ltree(f'{encode_path_for_ltree(data.parent_path)}') if data.parent_path else None,
         'archived': False,
         'type': data.type,
@@ -198,7 +198,7 @@ def update_item(item_id: UUID, data: PUTItem) -> dict:
         raise BadRequestException('Attributes do not match attribute template')
     item = db.session.query(ItemModel).filter_by(id=item_id).first()
     encoded_item_name = encode_label_for_ltree(data.name)
-    item.parent = data.parent
+    item.parent = data.parent if data.parent else None,
     item.parent_path = Ltree(f'{encode_path_for_ltree(data.parent_path)}') if data.parent_path else None
     item.type = data.type
     item.zone = data.zone

--- a/migrations/versions/212e0e60c178_add_items_table.py
+++ b/migrations/versions/212e0e60c178_add_items_table.py
@@ -25,7 +25,7 @@ def upgrade():
         sa.Column('parent_path', LtreeType()),
         sa.Column('restore_path', LtreeType()),
         sa.Column('archived', sa.Boolean(), nullable=False),
-        sa.Column('type', pg.ENUM('file', 'folder', name='type_enum', create_type=True), nullable=False),
+        sa.Column('type', pg.ENUM('file', 'folder', 'name_folder', name='type_enum', create_type=True), nullable=False),
         sa.Column('zone', sa.Integer(), nullable=False),
         sa.Column('name', sa.String(), nullable=False),
         sa.Column('size', sa.Integer()),
@@ -36,10 +36,19 @@ def upgrade():
         ),
         sa.PrimaryKeyConstraint('id'),
         sa.UniqueConstraint('id'),
-        sa.UniqueConstraint('parent_path', 'archived', 'zone', 'name', 'container_code'),
+        sa.UniqueConstraint('parent_path', 'archived', 'zone', 'name', 'container_code', 'container_type'),
+        sa.Index(
+            'zone',
+            'name',
+            'container_code',
+            'container_type',
+            unique=True,
+            postgresql_where=sa.Column('type') == 'name_folder',
+        ),
         schema='metadata',
     )
 
 
 def downgrade():
     op.drop_table('items', schema='metadata')
+    op.execute('drop type type_enum; drop type container_enum;')

--- a/migrations/versions/76ffd36326a3_add_time_columns_to_items_table.py
+++ b/migrations/versions/76ffd36326a3_add_time_columns_to_items_table.py
@@ -1,12 +1,11 @@
-"""Add time columns to items table
+"""Add time columns to items table.
 
 Revision ID: 76ffd36326a3
 Revises: cad81b7e09aa
 Create Date: 2022-04-13 13:23:46.380997
-
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '76ffd36326a3'
@@ -18,6 +17,7 @@ depends_on = None
 def upgrade():
     op.add_column('items', sa.Column('created_time', sa.DateTime(), nullable=False), schema='metadata')
     op.add_column('items', sa.Column('last_updated_time', sa.DateTime(), nullable=False), schema='metadata')
+
 
 def downgrade():
     op.drop_column('items', 'created_time', schema='metadata')

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -370,3 +370,24 @@ class TestItems:
         params = {'ids': [reused_item_ids[1], reused_item_ids[2]]}
         response = self.app.delete('/v1/item/batch/', params=params)
         assert response.status_code == 200
+
+    def test_18_create_name_folder_with_parent(self):
+            payload = {
+                'parent': '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+                'parent_path': 'folder1.folder2',
+                'type': 'name_folder',
+                'zone': 0,
+                'name': 'file',
+                'size': 0,
+                'owner': 'admin',
+                'container_code': reused_container_code,
+                'container_type': 'project',
+                'location_uri': 'https://example.com',
+                'version': '1.0',
+                'tags': [],
+                'system_tags': [],
+                'attribute_template_id': None,
+                'attributes': {},
+            }
+            response = self.app.post('/v1/item/', json=payload)
+            assert response.status_code == 422

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -42,6 +42,7 @@ class TestItems:
             'location_uri': 'https://example.com',
             'version': '1.0',
             'tags': [],
+            'system_tags': [],
             'attribute_template_id': None,
             'attributes': {},
         }
@@ -83,6 +84,7 @@ class TestItems:
             'location_uri': 'https://example.com',
             'version': '1.0',
             'tags': [],
+            'system_tags': [],
             'attribute_template_id': None,
             'attributes': {},
         }
@@ -131,6 +133,7 @@ class TestItems:
             'location_uri': 'https://example.com',
             'version': '1.0',
             'tags': [],
+            'system_tags': [],
             'attribute_template_id': None,
             'attributes': None,
         }
@@ -151,6 +154,7 @@ class TestItems:
             'location_uri': 'https://example.com',
             'version': '1.0',
             'tags': [],
+            'system_tags': [],
             'attribute_template_id': None,
             'attributes': None,
         }
@@ -173,6 +177,7 @@ class TestItems:
             'location_uri': 'https://example.com',
             'version': '1.0',
             'tags': [],
+            'system_tags': [],
             'attribute_template_id': None,
             'attributes': None,
         }
@@ -195,6 +200,7 @@ class TestItems:
             'location_uri': 'https://example.com',
             'version': '1.0',
             'tags': [],
+            'system_tags': [],
             'attribute_template_id': None,
             'attributes': None,
         }
@@ -215,6 +221,7 @@ class TestItems:
             'location_uri': 'https://example.com',
             'version': '1.0',
             'tags': [],
+            'system_tags': [],
             'attribute_template_id': None,
             'attributes': {},
         }
@@ -238,6 +245,7 @@ class TestItems:
             'location_uri': 'https://example.com',
             'version': '1.0',
             'tags': [],
+            'system_tags': [],
             'attribute_template_id': None,
             'attributes': {},
         }
@@ -277,6 +285,7 @@ class TestItems:
                     'location_uri': 'https://example.com',
                     'version': '1.0',
                     'tags': [],
+                    'system_tags': [],
                     'attribute_template_id': None,
                     'attributes': {},
                 },
@@ -293,6 +302,7 @@ class TestItems:
                     'location_uri': 'https://example.com',
                     'version': '1.0',
                     'tags': [],
+                    'system_tags': [],
                     'attribute_template_id': None,
                     'attributes': {},
                 },
@@ -328,6 +338,7 @@ class TestItems:
                     'location_uri': 'https://example.com',
                     'version': '1.0',
                     'tags': [],
+                    'system_tags': [],
                     'attribute_template_id': None,
                     'attributes': {},
                 },
@@ -344,6 +355,7 @@ class TestItems:
                     'location_uri': 'https://example.com',
                     'version': '1.0',
                     'tags': [],
+                    'system_tags': [],
                     'attribute_template_id': None,
                     'attributes': {},
                 },


### PR DESCRIPTION
## Summary

- Add support for name folders within projects:
	- Allow new `name_folder` item type.
	- Add validators to ensure that name folders do not include parent data and other item types do.
	- Add partial unique constraint to prevent duplicate name folders since their null values defy the old unique constraint.

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-900

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes

## Test Directions

Check expected behaviour for name folders in the task and ensure that they perform appropriately.
