### PR TITLE
PILOT-951 Allow client-specified ID for new item creation

### DIFF
--- a/app/api_registry.py
+++ b/app/api_registry.py
@@ -26,7 +26,7 @@ def is_db_online():
 
 
 def api_registry(app: FastAPI):
-    app.add_api_route('/v1/health', health([is_db_online]), tags=['Health'])
+    app.add_api_route('/v1/health/', health([is_db_online]), tags=['Health'])
     app.include_router(api_items.router, prefix='/v1/item', tags=['Items'])
     app.include_router(api_items.router_bulk, prefix='/v1/items', tags=['Items'])
     app.include_router(api_attribute_templates.router, prefix='/v1/template', tags=['Attribute templates'])

--- a/app/models/models_attribute_templates.py
+++ b/app/models/models_attribute_templates.py
@@ -29,7 +29,7 @@ class GETTemplate(BaseModel):
 
 
 class GETTemplates(BaseModel):
-    project_id: UUID
+    project_code: str
     page_size: int = 10
     page: int = 0
 
@@ -40,7 +40,7 @@ class GETTemplateResponse(APIResponse):
         example={
             'id': '85465212-168a-4f0c-a7aa-f3a19795d2ff',
             'name': 'template_name',
-            'project_id': '28c608ac-1693-4318-a1c4-412caf2cd74a',
+            'project_code': 'project0422',
             'attributes': [
                 {
                     'name': 'attribute_1',
@@ -73,7 +73,7 @@ class POSTTemplateAttributes(BaseModel):
 
 class POSTTemplate(BaseModel):
     name: str
-    project_id: UUID
+    project_code: str
     attributes: List[POSTTemplateAttributes]
 
 

--- a/app/models/models_items.py
+++ b/app/models/models_items.py
@@ -82,6 +82,7 @@ class GETItemResponse(APIResponse):
 
 
 class POSTItem(BaseModel):
+    id: Optional[UUID]
     parent: Optional[UUID] = Field(example='3fa85f64-5717-4562-b3fc-2c963f66afa6')
     parent_path: Optional[str] = Field(example='path.to.file')
     type: str = 'file'

--- a/app/models/sql_attribute_templates.py
+++ b/app/models/sql_attribute_templates.py
@@ -30,21 +30,21 @@ class AttributeTemplateModel(Base):
     __tablename__ = 'attribute_templates'
     id = Column(UUID(as_uuid=True), unique=True, primary_key=True)
     name = Column(String(), nullable=False)
-    project_id = Column(UUID(as_uuid=True), nullable=False)
+    project_code = Column(String(), nullable=False)
     attributes = Column(JSON())
 
     __table_args__ = ({'schema': ConfigClass.METADATA_SCHEMA},)
 
-    def __init__(self, name, project_id, attributes):
+    def __init__(self, name, project_code, attributes):
         self.id = uuid.uuid4()
         self.name = name
-        self.project_id = project_id
+        self.project_code = project_code
         self.attributes = attributes
 
     def to_dict(self):
         return {
             'id': str(self.id),
             'name': self.name,
-            'project_id': str(self.project_id),
+            'project_code': self.project_code,
             'attributes': self.attributes,
         }

--- a/app/models/sql_items.py
+++ b/app/models/sql_items.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import uuid
 from datetime import datetime
 
 from sqlalchemy import Boolean
@@ -64,8 +63,10 @@ class ItemModel(Base):
         {'schema': ConfigClass.METADATA_SCHEMA},
     )
 
-    def __init__(self, parent, parent_path, archived, type, zone, name, size, owner, container_code, container_type):
-        self.id = uuid.uuid4()
+    def __init__(
+        self, id, parent, parent_path, archived, type, zone, name, size, owner, container_code, container_type
+    ):
+        self.id = id
         self.parent = parent
         self.parent_path = parent_path
         self.archived = archived

--- a/app/routers/v1/attribute_templates/api_attribute_templates.py
+++ b/app/routers/v1/attribute_templates/api_attribute_templates.py
@@ -36,7 +36,7 @@ from app.routers.router_utils import set_api_response_error
 from .crud import create_template
 from .crud import delete_template_by_id
 from .crud import get_template_by_id
-from .crud import get_templates_by_project_id
+from .crud import get_templates_by_project_code
 from .crud import update_template
 
 router = APIRouter()
@@ -61,11 +61,11 @@ class APIAttributeTemplates:
     async def get_attribute_templates(self, params: GETTemplates = Depends(GETTemplates)):
         try:
             api_response = GETTemplateResponse()
-            get_templates_by_project_id(params, api_response)
+            get_templates_by_project_code(params, api_response)
         except Exception as e:
             _logger.exception(e)
             set_api_response_error(
-                api_response, f'Failed to get templates with project_id {params.project_id}', EAPIResponseCode.not_found
+                api_response, f'Failed to get templates with code {params.project_code}', EAPIResponseCode.not_found
             )
         return api_response.json_response()
 

--- a/app/routers/v1/attribute_templates/api_attribute_templates.py
+++ b/app/routers/v1/attribute_templates/api_attribute_templates.py
@@ -45,7 +45,7 @@ _logger = LoggerFactory('api_attribute_templates').get_logger()
 
 @cbv(router)
 class APIAttributeTemplates:
-    @router.get('/{id}', response_model=GETTemplateResponse, summary='Get an attribute template')
+    @router.get('/{id}/', response_model=GETTemplateResponse, summary='Get an attribute template')
     async def get_attribute_template(self, params: GETTemplate = Depends(GETTemplate)):
         try:
             api_response = GETTemplateResponse()

--- a/app/routers/v1/attribute_templates/crud.py
+++ b/app/routers/v1/attribute_templates/crud.py
@@ -35,8 +35,8 @@ def get_template_by_id(params: GETTemplate, api_response: APIResponse):
     api_response.result = template_query.first().to_dict()
 
 
-def get_templates_by_project_id(params: GETTemplates, api_response: APIResponse):
-    template_query = db.session.query(AttributeTemplateModel).filter_by(project_id=params.project_id)
+def get_templates_by_project_code(params: GETTemplates, api_response: APIResponse):
+    template_query = db.session.query(AttributeTemplateModel).filter_by(project_code=params.project_code)
     paginate(params, api_response, template_query, None)
 
 
@@ -57,7 +57,7 @@ def format_attributes_for_json(attributes: POSTTemplateAttributes) -> List[dict]
 def create_template(data: POSTTemplate, api_response: APIResponse):
     template_model_data = {
         'name': data.name,
-        'project_id': data.project_id,
+        'project_code': data.project_code,
         'attributes': format_attributes_for_json(data.attributes),
     }
     template = AttributeTemplateModel(**template_model_data)
@@ -72,7 +72,7 @@ def update_template(template_id: UUID, data: PUTTemplate, api_response: APIRespo
     if not template:
         raise EntityNotFoundException()
     template.name = data.name
-    template.project_id = data.project_id
+    template.project_code = data.project_code
     template.attributes = format_attributes_for_json(data.attributes)
     db.session.commit()
     db.session.refresh(template)

--- a/app/routers/v1/items/crud.py
+++ b/app/routers/v1/items/crud.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import time
+import uuid
 from datetime import datetime
 from uuid import UUID
 
@@ -153,6 +154,7 @@ def create_item(data: POSTItem) -> dict:
         raise BadRequestException('Attributes do not match attribute template')
     encoded_item_name = encode_label_for_ltree(data.name)
     item_model_data = {
+        'id': data.id if data.id else uuid.uuid4(),
         'parent': data.parent if data.parent else None,
         'parent_path': Ltree(f'{encode_path_for_ltree(data.parent_path)}') if data.parent_path else None,
         'archived': False,

--- a/migrations/versions/5df5e2987093_add_attribute_templates_table.py
+++ b/migrations/versions/5df5e2987093_add_attribute_templates_table.py
@@ -20,7 +20,7 @@ def upgrade():
         'attribute_templates',
         sa.Column('id', UUID(), nullable=False),
         sa.Column('name', sa.String(), nullable=False),
-        sa.Column('project_id', UUID(), nullable=False),
+        sa.Column('project_code', sa.String(), nullable=False),
         sa.Column('attributes', sa.JSON()),
         sa.PrimaryKeyConstraint('id'),
         sa.UniqueConstraint('id'),

--- a/tests/test_attribute_templates.py
+++ b/tests/test_attribute_templates.py
@@ -21,17 +21,17 @@ from fastapi.testclient import TestClient
 from app.main import app
 
 reused_template_id = None
-reused_project_id = '3fa85f64-5717-4562-b3fc-2c963f66afa6'
+reused_project_code = 'project0422'
 
 
 class TestAttributeTemplates:
     app = TestClient(app)
 
     @pytest.mark.dependency(name='test_01')
-    def test_01_create_attribute_template(self):
+    def test_create_attribute_template_200(self):
         payload = {
             'name': 'template_1',
-            'project_id': reused_project_id,
+            'project_code': reused_project_code,
             'attributes': [
                 {'name': 'attribute_1', 'optional': True, 'type': 'multiple_choice', 'options': ['val1', 'val2']}
             ],
@@ -42,22 +42,22 @@ class TestAttributeTemplates:
         assert response.status_code == 200
 
     @pytest.mark.dependency(depends=['test_01'])
-    def test_02_get_attribute_template_by_id(self):
+    def test_get_attribute_template_by_id_200(self):
         response = self.app.get(f'/v1/template/{reused_template_id}')
         assert response.status_code == 200
 
     @pytest.mark.dependency(depends=['test_01'])
-    def test_03_get_attribute_template_by_project_id(self):
-        params = {'project_id': reused_project_id}
+    def test_get_attribute_template_by_project_code_200(self):
+        params = {'project_code': reused_project_code}
         response = self.app.get('/v1/template/', params=params)
         assert response.status_code == 200
 
     @pytest.mark.dependency(depends=['test_01'])
-    def test_04_update_attribute_template(self):
+    def test_update_attribute_template_200(self):
         params = {'id': reused_template_id}
         payload = {
             'name': 'template_1',
-            'project_id': reused_project_id,
+            'project_code': reused_project_code,
             'attributes': [
                 {'name': 'attribute_1', 'optional': True, 'type': 'multiple_choice', 'options': ['val1', 'val2']},
                 {'name': 'attribute_2', 'optional': True, 'type': 'text', 'options': []},
@@ -68,15 +68,15 @@ class TestAttributeTemplates:
         assert len(loads(response.text)['result']['attributes']) == 2
 
     @pytest.mark.dependency(depends=['test_01'])
-    def test_05_delete_attribute_template(self):
+    def test_delete_attribute_template_200(self):
         params = {'id': reused_template_id}
         response = self.app.delete('/v1/template/', params=params)
         assert response.status_code == 200
 
-    def test_06_create_attribute_template_wrong_type(self):
+    def test_create_attribute_template_wrong_type_422(self):
         payload = {
             'name': 'template_1',
-            'project_id': reused_project_id,
+            'project_code': reused_project_code,
             'attributes': [{'name': 'attribute_1', 'optional': True, 'type': 'invalid', 'options': 'val1, val2'}],
         }
         response = self.app.post('/v1/template/', json=payload)


### PR DESCRIPTION
## Summary

- Allow the create items endpoints to accept a custom ID in their payload.
- Fix attribute template to use project code instead of project ID.

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-951

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes
- [ ] No

## Test Directions

Test creating items with and without specifying an ID.
