### PR TITLE
PILOT-932 Archive folders recursively

### DIFF
--- a/app/routers/v1/items/api_items.py
+++ b/app/routers/v1/items/api_items.py
@@ -97,6 +97,8 @@ class APIItems:
         try:
             api_response = PATCHItemResponse()
             archive_item_by_id(params, api_response)
+        except BadRequestException as e:
+            set_api_response_error(api_response, str(e), EAPIResponseCode.bad_request)
         except Exception as e:
             _logger.exception(e)
             set_api_response_error(api_response, 'Failed to archive item', EAPIResponseCode.internal_error)

--- a/app/routers/v1/items/api_items.py
+++ b/app/routers/v1/items/api_items.py
@@ -38,6 +38,7 @@ from app.models.models_items import PUTItem
 from app.models.models_items import PUTItemResponse
 from app.models.models_items import PUTItems
 from app.routers.router_exceptions import BadRequestException
+from app.routers.router_exceptions import EntityNotFoundException
 from app.routers.router_utils import set_api_response_error
 
 from .crud import archive_item_by_id
@@ -97,6 +98,8 @@ class APIItems:
         try:
             api_response = PATCHItemResponse()
             archive_item_by_id(params, api_response)
+        except EntityNotFoundException:
+            set_api_response_error(api_response, f'Failed to get item with id {params.id}', EAPIResponseCode.not_found)
         except BadRequestException as e:
             set_api_response_error(api_response, str(e), EAPIResponseCode.bad_request)
         except Exception as e:

--- a/app/routers/v1/items/crud.py
+++ b/app/routers/v1/items/crud.py
@@ -264,7 +264,7 @@ def get_restore_destination_id(container_code: str, zone: int, restore_path: Ltr
     destination_path = None
     decoded_restore_path_labels = decoded_restore_path.split('.')
     if len(decoded_restore_path_labels) > 1:
-        destination_name = decoded_restore_path_labels[:-1]
+        destination_name = decoded_restore_path_labels[-1]
         destination_path = '.'.join(decoded_restore_path_labels[:-1])
     destination_query = db.session.query(ItemModel).filter(
         ItemModel.container_code == container_code,

--- a/app/routers/v1/items/crud.py
+++ b/app/routers/v1/items/crud.py
@@ -143,7 +143,7 @@ def get_items_by_location(params: GETItemsByLocation, api_response: APIResponse)
     if params.name:
         item_query = item_query.filter(ItemModel.name == encode_label_for_ltree(params.name))
     if params.parent_path:
-        search_path = f'{encode_path_for_ltree(params.parent_path)}'
+        search_path = encode_path_for_ltree(params.parent_path)
         if params.recursive:
             search_path += '.*'
         item_query = item_query.filter(

--- a/poetry.lock
+++ b/poetry.lock
@@ -368,17 +368,6 @@ toml = "*"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
-name = "pytest-dependency"
-version = "0.5.1"
-description = "Manage dependencies of tests"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-pytest = ">=3.6.0"
-
-[[package]]
 name = "python-dotenv"
 version = "0.19.1"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -524,11 +513,11 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "typing-extensions"
-version = "4.1.1"
-description = "Backported and Experimental Type Hints for Python 3.6+"
+version = "4.2.0"
+description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [[package]]
 name = "urllib3"
@@ -562,7 +551,7 @@ standard = ["websockets (>=10.0)", "httptools (>=0.2.0,<0.4.0)", "watchgod (>=0.
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "273449fab47e209ba04a649d6287ed207e79f8ce9a5c47a499976f8d63e60881"
+content-hash = "71e23879fa6864f9c6aa00c2be4e0dc3962877bb9d3da9bb802217b20c711bc6"
 
 [metadata.files]
 anyio = [
@@ -865,9 +854,6 @@ pytest = [
     {file = "pytest-6.2.4-py3-none-any.whl", hash = "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"},
     {file = "pytest-6.2.4.tar.gz", hash = "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b"},
 ]
-pytest-dependency = [
-    {file = "pytest-dependency-0.5.1.tar.gz", hash = "sha256:c2a892906192663f85030a6ab91304e508e546cddfe557d692d61ec57a1d946b"},
-]
 python-dotenv = [
     {file = "python-dotenv-0.19.1.tar.gz", hash = "sha256:14f8185cc8d494662683e6914addcb7e95374771e707601dfc70166946b4c4b8"},
     {file = "python_dotenv-0.19.1-py2.py3-none-any.whl", hash = "sha256:bbd3da593fc49c249397cbfbcc449cf36cb02e75afc8157fcc6a81df6fb7750a"},
@@ -942,8 +928,8 @@ toml = [
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
-    {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
+    {file = "typing_extensions-4.2.0-py3-none-any.whl", hash = "sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708"},
+    {file = "typing_extensions-4.2.0.tar.gz", hash = "sha256:f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376"},
 ]
 urllib3 = [
     {file = "urllib3-1.25.11-py2.py3-none-any.whl", hash = "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ python-json-logger = "0.1.11"
 
 [tool.poetry.dev-dependencies]
 pytest = "6.2.4"
-pytest-dependency = "0.5.1"
 coverage = "5.3"
 flake8 = "4.0.1"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import uuid
+from json import loads
 
 import pytest
 from fastapi.testclient import TestClient
@@ -22,8 +23,9 @@ from app.main import app
 
 app = TestClient(app)
 
+
 @pytest.fixture(scope='session')
-def test_items():
+def test_items() -> list[str]:
     test_item_ids = {
         'name_folder': str(uuid.uuid4()),
         'folder': str(uuid.uuid4()),
@@ -126,3 +128,19 @@ def test_items():
     for id in test_item_ids.values():
         params = {'id': id}
         app.delete('/v1/item/', params=params)
+
+
+@pytest.fixture(scope='session')
+def test_attribute_template() -> str:
+    payload = {
+        'name': 'test_template',
+        'project_code': 'test_project',
+        'attributes': [
+            {'name': 'attribute_1', 'optional': True, 'type': 'multiple_choice', 'options': ['val1', 'val2']}
+        ],
+    }
+    response = app.post('/v1/template/', json=payload)
+    attribute_template_id = loads(response.text)['result']['id']
+    yield attribute_template_id
+    params = {'id': attribute_template_id}
+    app.delete('/v1/template/', params=params)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,128 @@
+# Copyright (C) 2022 Indoc Research
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+app = TestClient(app)
+
+@pytest.fixture(scope='session')
+def test_items():
+    test_item_ids = {
+        'name_folder': str(uuid.uuid4()),
+        'folder': str(uuid.uuid4()),
+        'file': str(uuid.uuid4()),
+        'file_2': str(uuid.uuid4()),
+        'file_3': str(uuid.uuid4()),
+    }
+    payload = {
+        'items': [
+            {
+                'id': test_item_ids['name_folder'],
+                'parent': None,
+                'parent_path': None,
+                'type': 'name_folder',
+                'zone': 0,
+                'name': 'user',
+                'size': 0,
+                'owner': 'user',
+                'container_code': 'test_project',
+                'container_type': 'project',
+                'location_uri': '',
+                'version': '',
+            },
+            {
+                'id': test_item_ids['folder'],
+                'parent': test_item_ids['name_folder'],
+                'parent_path': 'user',
+                'type': 'folder',
+                'zone': 0,
+                'name': 'test_folder',
+                'size': 0,
+                'owner': 'user',
+                'container_code': 'test_project',
+                'container_type': 'project',
+                'location_uri': '',
+                'version': '',
+                'tags': [],
+                'system_tags': [],
+                'attribute_template_id': None,
+                'attributes': {},
+            },
+            {
+                'id': test_item_ids['file'],
+                'parent': test_item_ids['folder'],
+                'parent_path': 'user.test_folder',
+                'type': 'file',
+                'zone': 0,
+                'name': 'test_file.txt',
+                'size': 100,
+                'owner': 'user',
+                'container_code': 'test_project',
+                'container_type': 'project',
+                'location_uri': '',
+                'version': '',
+                'tags': [],
+                'system_tags': [],
+                'attribute_template_id': None,
+                'attributes': {},
+            },
+            {
+                'id': test_item_ids['file_2'],
+                'parent': test_item_ids['folder'],
+                'parent_path': 'user.test_folder',
+                'type': 'file',
+                'zone': 0,
+                'name': 'test_file_2.txt',
+                'size': 100,
+                'owner': 'user',
+                'container_code': 'test_project',
+                'container_type': 'project',
+                'location_uri': '',
+                'version': '',
+                'tags': [],
+                'system_tags': [],
+                'attribute_template_id': None,
+                'attributes': {},
+            },
+            {
+                'id': test_item_ids['file_3'],
+                'parent': test_item_ids['folder'],
+                'parent_path': 'user.test_folder',
+                'type': 'file',
+                'zone': 0,
+                'name': 'test_file_3.txt',
+                'size': 100,
+                'owner': 'user',
+                'container_code': 'test_project',
+                'container_type': 'project',
+                'location_uri': '',
+                'version': '',
+                'tags': [],
+                'system_tags': [],
+                'attribute_template_id': None,
+                'attributes': {},
+            },
+        ],
+    }
+    app.post('/v1/items/batch/', json=payload)
+    yield test_item_ids
+    for id in test_item_ids.values():
+        params = {'id': id}
+        app.delete('/v1/item/', params=params)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import random
 import uuid
 from json import loads
 
@@ -24,19 +25,29 @@ from app.main import app
 app = TestClient(app)
 
 
-@pytest.fixture(scope='session')
-def test_items() -> list[str]:
-    test_item_ids = {
-        'name_folder': str(uuid.uuid4()),
-        'folder': str(uuid.uuid4()),
-        'file_1': str(uuid.uuid4()),
-        'file_2': str(uuid.uuid4()),
-        'file_3': str(uuid.uuid4()),
+def generate_random_container_code() -> str:
+    random_container_code = 'test_'
+    for _ in range(8):
+        random_container_code += chr(random.randint(32, 126))
+    return random_container_code
+
+
+@pytest.fixture(scope='function')
+def test_items() -> dict:
+    props = {
+        'container_code': generate_random_container_code(),
+        'ids': {
+            'name_folder': str(uuid.uuid4()),
+            'folder': str(uuid.uuid4()),
+            'file_1': str(uuid.uuid4()),
+            'file_2': str(uuid.uuid4()),
+            'file_3': str(uuid.uuid4()),
+        },
     }
     payload = {
         'items': [
             {
-                'id': test_item_ids['name_folder'],
+                'id': props['ids']['name_folder'],
                 'parent': None,
                 'parent_path': None,
                 'type': 'name_folder',
@@ -44,21 +55,21 @@ def test_items() -> list[str]:
                 'name': 'user',
                 'size': 0,
                 'owner': 'user',
-                'container_code': 'test_project',
+                'container_code': props['container_code'],
                 'container_type': 'project',
                 'location_uri': '',
                 'version': '',
             },
             {
-                'id': test_item_ids['folder'],
-                'parent': test_item_ids['name_folder'],
+                'id': props['ids']['folder'],
+                'parent': props['ids']['name_folder'],
                 'parent_path': 'user',
                 'type': 'folder',
                 'zone': 0,
                 'name': 'test_folder',
                 'size': 0,
                 'owner': 'user',
-                'container_code': 'test_project',
+                'container_code': props['container_code'],
                 'container_type': 'project',
                 'location_uri': '',
                 'version': '',
@@ -68,15 +79,15 @@ def test_items() -> list[str]:
                 'attributes': {},
             },
             {
-                'id': test_item_ids['file_1'],
-                'parent': test_item_ids['folder'],
+                'id': props['ids']['file_1'],
+                'parent': props['ids']['folder'],
                 'parent_path': 'user.test_folder',
                 'type': 'file',
                 'zone': 0,
                 'name': 'test_file_1.txt',
                 'size': 100,
                 'owner': 'user',
-                'container_code': 'test_project',
+                'container_code': props['container_code'],
                 'container_type': 'project',
                 'location_uri': '',
                 'version': '',
@@ -86,15 +97,15 @@ def test_items() -> list[str]:
                 'attributes': {},
             },
             {
-                'id': test_item_ids['file_2'],
-                'parent': test_item_ids['folder'],
+                'id': props['ids']['file_2'],
+                'parent': props['ids']['folder'],
                 'parent_path': 'user.test_folder',
                 'type': 'file',
                 'zone': 0,
                 'name': 'test_file_2.txt',
                 'size': 100,
                 'owner': 'user',
-                'container_code': 'test_project',
+                'container_code': props['container_code'],
                 'container_type': 'project',
                 'location_uri': '',
                 'version': '',
@@ -104,15 +115,15 @@ def test_items() -> list[str]:
                 'attributes': {},
             },
             {
-                'id': test_item_ids['file_3'],
-                'parent': test_item_ids['folder'],
+                'id': props['ids']['file_3'],
+                'parent': props['ids']['folder'],
                 'parent_path': 'user.test_folder',
                 'type': 'file',
                 'zone': 0,
                 'name': 'test_file_3.txt',
                 'size': 100,
                 'owner': 'user',
-                'container_code': 'test_project',
+                'container_code': props['container_code'],
                 'container_type': 'project',
                 'location_uri': '',
                 'version': '',
@@ -124,13 +135,13 @@ def test_items() -> list[str]:
         ],
     }
     app.post('/v1/items/batch/', json=payload)
-    yield test_item_ids
-    for id in test_item_ids.values():
+    yield props
+    for id in props['ids'].values():
         params = {'id': id}
         app.delete('/v1/item/', params=params)
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope='function')
 def test_attribute_template() -> str:
     payload = {
         'name': 'test_template',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ def test_items() -> list[str]:
     test_item_ids = {
         'name_folder': str(uuid.uuid4()),
         'folder': str(uuid.uuid4()),
-        'file': str(uuid.uuid4()),
+        'file_1': str(uuid.uuid4()),
         'file_2': str(uuid.uuid4()),
         'file_3': str(uuid.uuid4()),
     }
@@ -68,12 +68,12 @@ def test_items() -> list[str]:
                 'attributes': {},
             },
             {
-                'id': test_item_ids['file'],
+                'id': test_item_ids['file_1'],
                 'parent': test_item_ids['folder'],
                 'parent_path': 'user.test_folder',
                 'type': 'file',
                 'zone': 0,
-                'name': 'test_file.txt',
+                'name': 'test_file_1.txt',
                 'size': 100,
                 'owner': 'user',
                 'container_code': 'test_project',

--- a/tests/test_attribute_templates.py
+++ b/tests/test_attribute_templates.py
@@ -15,69 +15,58 @@
 
 from json import loads
 
-import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
 
-reused_template_id = None
-reused_project_code = 'project0422'
+app = TestClient(app)
 
 
 class TestAttributeTemplates:
-    app = TestClient(app)
+    def test_get_attribute_template_by_id_200(self, test_attribute_template):
+        response = app.get(f'/v1/template/{test_attribute_template}')
+        assert response.status_code == 200
 
-    @pytest.mark.dependency(name='test_01')
+    def test_get_attribute_template_by_project_code_200(self, test_attribute_template):
+        params = {'project_code': 'test_project'}
+        response = app.get('/v1/template/', params=params)
+        assert response.status_code == 200
+
     def test_create_attribute_template_200(self):
         payload = {
             'name': 'template_1',
-            'project_code': reused_project_code,
+            'project_code': 'test_project',
             'attributes': [
                 {'name': 'attribute_1', 'optional': True, 'type': 'multiple_choice', 'options': ['val1', 'val2']}
             ],
         }
-        response = self.app.post('/v1/template/', json=payload)
-        global reused_template_id
-        reused_template_id = loads(response.text)['result']['id']
-        assert response.status_code == 200
-
-    @pytest.mark.dependency(depends=['test_01'])
-    def test_get_attribute_template_by_id_200(self):
-        response = self.app.get(f'/v1/template/{reused_template_id}')
-        assert response.status_code == 200
-
-    @pytest.mark.dependency(depends=['test_01'])
-    def test_get_attribute_template_by_project_code_200(self):
-        params = {'project_code': reused_project_code}
-        response = self.app.get('/v1/template/', params=params)
-        assert response.status_code == 200
-
-    @pytest.mark.dependency(depends=['test_01'])
-    def test_update_attribute_template_200(self):
-        params = {'id': reused_template_id}
-        payload = {
-            'name': 'template_1',
-            'project_code': reused_project_code,
-            'attributes': [
-                {'name': 'attribute_1', 'optional': True, 'type': 'multiple_choice', 'options': ['val1', 'val2']},
-                {'name': 'attribute_2', 'optional': True, 'type': 'text', 'options': []},
-            ],
-        }
-        response = self.app.put('/v1/template/', json=payload, params=params)
-        assert response.status_code == 200
-        assert len(loads(response.text)['result']['attributes']) == 2
-
-    @pytest.mark.dependency(depends=['test_01'])
-    def test_delete_attribute_template_200(self):
-        params = {'id': reused_template_id}
-        response = self.app.delete('/v1/template/', params=params)
+        response = app.post('/v1/template/', json=payload)
         assert response.status_code == 200
 
     def test_create_attribute_template_wrong_type_422(self):
         payload = {
             'name': 'template_1',
-            'project_code': reused_project_code,
+            'project_code': 'test_project',
             'attributes': [{'name': 'attribute_1', 'optional': True, 'type': 'invalid', 'options': 'val1, val2'}],
         }
-        response = self.app.post('/v1/template/', json=payload)
+        response = app.post('/v1/template/', json=payload)
         assert response.status_code == 422
+
+    def test_update_attribute_template_200(self, test_attribute_template):
+        params = {'id': test_attribute_template}
+        payload = {
+            'name': 'template_1',
+            'project_code': 'test_project',
+            'attributes': [
+                {'name': 'attribute_1', 'optional': True, 'type': 'multiple_choice', 'options': ['val1', 'val2']},
+                {'name': 'attribute_2', 'optional': True, 'type': 'text', 'options': []},
+            ],
+        }
+        response = app.put('/v1/template/', json=payload, params=params)
+        assert response.status_code == 200
+        assert len(loads(response.text)['result']['attributes']) == 2
+
+    def test_delete_attribute_template_200(self, test_attribute_template):
+        params = {'id': test_attribute_template}
+        response = app.delete('/v1/template/', params=params)
+        assert response.status_code == 200

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -14,381 +14,282 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from json import loads
+import uuid
 
-import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
 
-reused_item_ids = []
-reused_container_code = 'test_container'
+app = TestClient(app)
 
 
 class TestItems:
-    app = TestClient(app)
+    cleanup_item_ids = []
 
-    @pytest.mark.dependency(name='test_01')
-    def test_create_item_200(self):
-        payload = {
-            'parent': '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-            'parent_path': 'folder1.folder2',
-            'type': 'file',
-            'zone': 0,
-            'name': 'file',
-            'size': 0,
-            'owner': 'admin',
-            'container_code': reused_container_code,
-            'container_type': 'project',
-            'location_uri': 'https://example.com',
-            'version': '1.0',
-            'tags': [],
-            'system_tags': [],
-            'attribute_template_id': None,
-            'attributes': {},
-        }
-        response = self.app.post('/v1/item/', json=payload)
-        global reused_item_ids
-        reused_item_ids.append(loads(response.text)['result']['id'])
+    @classmethod
+    def teardown_class(cls):
+        for id in cls.cleanup_item_ids:
+            params = {'id': id}
+            app.delete('/v1/item/', params=params)
+
+    def test_get_item_by_id_200(self, test_items):
+        response = app.get(f'/v1/item/{test_items["file"]}/')
         assert response.status_code == 200
-
-    @pytest.mark.dependency(depends=['test_01'])
-    def test_get_item_by_id_200(self):
-        response = self.app.get(f'/v1/item/{reused_item_ids[0]}/')
-        assert response.status_code == 200
-
-    @pytest.mark.dependency(depends=['test_01'])
+    
     def test_get_item_by_location_200(self):
         params = {
-            'parent_path': 'folder1.folder2',
+            'parent_path': 'user.test_folder',
+            'name': 'test_file.txt',
             'archived': False,
             'zone': 0,
-            'container_code': reused_container_code,
+            'container_code': 'test_project',
             'recursive': False,
         }
-        response = self.app.get('/v1/items/search/', params=params)
+        response = app.get('/v1/items/search/', params=params)
         assert response.status_code == 200
-
-    @pytest.mark.dependency(depends=['test_01'])
-    def test_update_item_200(self):
-        params = {'id': reused_item_ids[0]}
-        payload = {
-            'parent': '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-            'parent_path': 'folder1.folder2',
-            'type': 'file',
-            'zone': 0,
-            'name': 'file_renamed',
-            'size': 0,
-            'owner': 'admin',
-            'container_code': reused_container_code,
-            'container_type': 'project',
-            'location_uri': 'https://example.com',
-            'version': '1.0',
-            'tags': [],
-            'system_tags': [],
-            'attribute_template_id': None,
-            'attributes': {},
-        }
-        response = self.app.put('/v1/item/', json=payload, params=params)
-        assert response.status_code == 200
-
-    @pytest.mark.dependency(depends=['test_01'])
-    def test_trash_item_200(self):
-        params = {
-            'id': reused_item_ids[0],
-            'archived': True,
-        }
-        response = self.app.patch('/v1/item/', params=params)
-        assert response.status_code == 200
-
-    @pytest.mark.dependency(depends=['test_01'])
-    def test_restore_item_200(self):
-        params = {
-            'id': reused_item_ids[0],
-            'archived': False,
-        }
-        response = self.app.patch('/v1/item/', params=params)
-        assert response.status_code == 200
-
+    
     def test_get_item_by_location_missing_zone_422(self):
         params = {
-            'parent_path': 'folder1.folder2',
+            'parent_path': 'user.test_folder',
+            'name': 'test_file.txt',
             'archived': False,
-            'container_code': reused_container_code,
+            'container_code': 'test_project',
             'recursive': False,
         }
-        response = self.app.get('/v1/item/search/', params=params)
+        response = app.get('/v1/item/search/', params=params)
         assert response.status_code == 422
+    
+    def test_get_items_by_id_batch_200(self, test_items):
+        params = {'ids': [test_items['name_folder'], test_items['folder'], test_items['file']]}
+        response = app.get('/v1/items/batch/', params=params)
+        assert response.status_code == 200
 
+    def test_create_item_200(self):
+        item_id = str(uuid.uuid4())
+        self.cleanup_item_ids.append(item_id)
+        payload = {
+            'id': item_id,
+            'parent': '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+            'parent_path': 'user.test_folder',
+            'type': 'file',
+            'zone': 0,
+            'name': 'test_file.txt',
+            'size': 0,
+            'owner': 'admin',
+            'container_code': 'create_item_200',
+            'container_type': 'project',
+            'location_uri': '',
+            'version': '',
+            'tags': [],
+            'system_tags': [],
+            'attribute_template_id': None,
+            'attributes': {},
+        }
+        response = app.post('/v1/item/', json=payload)
+        assert response.status_code == 200
+    
+    def test_create_items_batch_200(self):
+        item_ids = [str(uuid.uuid4()), str(uuid.uuid4())]
+        for id in item_ids:
+            self.cleanup_item_ids.append(id)
+        payload = {
+            'items': [
+                {
+                    'id': item_ids[0],
+                    'parent': '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+                    'parent_path': 'user.folder',
+                    'type': 'file',
+                    'zone': 0,
+                    'name': 'file_1.txt',
+                    'size': 0,
+                    'owner': 'user',
+                    'container_code': 'create_items_batch',
+                    'container_type': 'project',
+                    'location_uri': '',
+                    'version': '',
+                    'tags': [],
+                    'system_tags': [],
+                    'attribute_template_id': None,
+                    'attributes': {},
+                },
+                {
+                    'id': item_ids[1],
+                    'parent': '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+                    'parent_path': 'user.folder',
+                    'type': 'file',
+                    'zone': 0,
+                    'name': 'file_2.txt',
+                    'size': 0,
+                    'owner': 'user',
+                    'container_code': 'create_items_batch',
+                    'container_type': 'project',
+                    'location_uri': '',
+                    'version': '',
+                    'tags': [],
+                    'system_tags': [],
+                    'attribute_template_id': None,
+                    'attributes': {},
+                },
+            ]
+        }
+        response = app.post('/v1/items/batch/', json=payload)
+        assert response.status_code == 200
+    
     def test_create_item_wrong_type_422(self):
         payload = {
+            'id': str(uuid.uuid4()),
             'parent': '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-            'parent_path': 'folder1.folder2',
+            'parent_path': 'user.test_folder',
             'type': 'invalid',
             'zone': 0,
-            'name': 'file',
+            'name': 'test_file.txt',
             'size': 0,
             'owner': 'admin',
-            'container_code': reused_container_code,
+            'container_code': 'create_item_200',
             'container_type': 'project',
-            'location_uri': 'https://example.com',
-            'version': '1.0',
+            'location_uri': '',
+            'version': '',
             'tags': [],
             'system_tags': [],
             'attribute_template_id': None,
-            'attributes': None,
+            'attributes': {},
         }
-        response = self.app.post('/v1/item/', json=payload)
+        response = app.post('/v1/item/', json=payload)
         assert response.status_code == 422
-
+    
     def test_create_item_wrong_container_type_422(self):
         payload = {
+            'id': str(uuid.uuid4()),
             'parent': '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-            'parent_path': 'folder1.folder2',
+            'parent_path': 'user.test_folder',
             'type': 'file',
             'zone': 0,
-            'name': 'file',
+            'name': 'test_file.txt',
             'size': 0,
             'owner': 'admin',
-            'container_code': reused_container_code,
+            'container_code': 'create_item_200',
             'container_type': 'invalid',
-            'location_uri': 'https://example.com',
-            'version': '1.0',
-            'tags': [],
-            'system_tags': [],
-            'attribute_template_id': None,
-            'attributes': None,
-        }
-        response = self.app.post('/v1/item/', json=payload)
-        assert response.status_code == 422
-
-    @pytest.mark.dependency(depends=['test_01'])
-    def test_update_item_wrong_type_422(self):
-        params = {'id': reused_item_ids[0]}
-        payload = {
-            'parent': '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-            'parent_path': 'folder1.folder2',
-            'type': 'invalid',
-            'zone': 0,
-            'name': 'file_renamed',
-            'size': 0,
-            'owner': 'admin',
-            'container_code': reused_container_code,
-            'container_type': 'project',
-            'location_uri': 'https://example.com',
-            'version': '1.0',
-            'tags': [],
-            'system_tags': [],
-            'attribute_template_id': None,
-            'attributes': None,
-        }
-        response = self.app.put('/v1/item/', json=payload, params=params)
-        assert response.status_code == 422
-
-    @pytest.mark.dependency(depends=['test_01'])
-    def test_update_item_wrong_container_type_422(self):
-        params = {'id': reused_item_ids[0]}
-        payload = {
-            'parent': '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-            'parent_path': 'folder1.folder2',
-            'type': 'file',
-            'zone': 0,
-            'name': 'file_renamed',
-            'size': 0,
-            'owner': 'admin',
-            'container_code': reused_container_code,
-            'container_type': 'invalid',
-            'location_uri': 'https://example.com',
-            'version': '1.0',
-            'tags': [],
-            'system_tags': [],
-            'attribute_template_id': None,
-            'attributes': None,
-        }
-        response = self.app.put('/v1/item/', json=payload, params=params)
-        assert response.status_code == 422
-
-    def test_rename_item_on_conflict_200(self):
-        payload = {
-            'parent': '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-            'parent_path': 'folder1.folder2',
-            'type': 'file',
-            'zone': 0,
-            'name': 'conflict',
-            'size': 0,
-            'owner': 'admin',
-            'container_code': reused_container_code,
-            'container_type': 'project',
-            'location_uri': 'https://example.com',
-            'version': '1.0',
+            'location_uri': '',
+            'version': '',
             'tags': [],
             'system_tags': [],
             'attribute_template_id': None,
             'attributes': {},
         }
-        response = self.app.post('/v1/item/', json=payload)
-        item_1_id = loads(response.text)['result']['id']
-        params = {
-            'id': item_1_id,
-            'archived': True,
-        }
-        self.app.patch('/v1/item/', params=params)
-        payload = {
-            'parent': '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-            'parent_path': 'folder1.folder2',
-            'type': 'file',
-            'zone': 0,
-            'name': 'conflict',
-            'size': 0,
-            'owner': 'admin',
-            'container_code': reused_container_code,
-            'container_type': 'project',
-            'location_uri': 'https://example.com',
-            'version': '1.0',
-            'tags': [],
-            'system_tags': [],
-            'attribute_template_id': None,
-            'attributes': {},
-        }
-        response = self.app.post('/v1/item/', json=payload)
-        item_2_id = loads(response.text)['result']['id']
-        params = {
-            'id': item_1_id,
-            'archived': False,
-        }
-        response = self.app.patch('/v1/item/', params=params)
-        assert response.status_code == 200
-        assert '_' in loads(response.text)['result']['name']
-        params = {'id': item_1_id}
-        self.app.delete('/v1/item', params=params)
-        params = {'id': item_2_id}
-        self.app.delete('/v1/item', params=params)
-
-    @pytest.mark.dependency(depends=['test_01'])
-    def test_delete_item_200(self):
-        params = {'id': reused_item_ids[0]}
-        response = self.app.delete('/v1/item/', params=params)
-        assert response.status_code == 200
-
-    @pytest.mark.dependency(name='test_14')
-    def test_create_items_batch_200(self):
-        payload = {
-            'items': [
-                {
-                    'parent': '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-                    'parent_path': 'folder1.folder2',
-                    'type': 'file',
-                    'zone': 0,
-                    'name': 'file_1',
-                    'size': 0,
-                    'owner': 'admin',
-                    'container_code': reused_container_code,
-                    'container_type': 'project',
-                    'location_uri': 'https://example.com',
-                    'version': '1.0',
-                    'tags': [],
-                    'system_tags': [],
-                    'attribute_template_id': None,
-                    'attributes': {},
-                },
-                {
-                    'parent': '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-                    'parent_path': 'folder1.folder2',
-                    'type': 'file',
-                    'zone': 0,
-                    'name': 'file_2',
-                    'size': 0,
-                    'owner': 'admin',
-                    'container_code': reused_container_code,
-                    'container_type': 'project',
-                    'location_uri': 'https://example.com',
-                    'version': '1.0',
-                    'tags': [],
-                    'system_tags': [],
-                    'attribute_template_id': None,
-                    'attributes': {},
-                },
-            ]
-        }
-        response = self.app.post('/v1/items/batch/', json=payload)
-        global reused_item_ids
-        reused_item_ids.append(loads(response.text)['result'][0]['id'])
-        reused_item_ids.append(loads(response.text)['result'][1]['id'])
-        assert response.status_code == 200
-
-    @pytest.mark.dependency(depends=['test_14'])
-    def test_get_items_by_id_batch_200(self):
-        params = {'ids': [reused_item_ids[1], reused_item_ids[2]]}
-        response = self.app.get('/v1/items/batch/', params=params)
-        assert response.status_code == 200
-
-    @pytest.mark.dependency(depends=['test_14'])
-    def test_update_items_batch_200(self):
-        params = {'ids': [reused_item_ids[1], reused_item_ids[2]]}
-        payload = {
-            'items': [
-                {
-                    'parent': '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-                    'parent_path': 'folder1.folder2.folder3',
-                    'type': 'file',
-                    'zone': 0,
-                    'name': 'file_1',
-                    'size': 0,
-                    'owner': 'admin',
-                    'container_code': reused_container_code,
-                    'container_type': 'project',
-                    'location_uri': 'https://example.com',
-                    'version': '1.0',
-                    'tags': [],
-                    'system_tags': [],
-                    'attribute_template_id': None,
-                    'attributes': {},
-                },
-                {
-                    'parent': '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-                    'parent_path': 'folder1.folder2.folder3',
-                    'type': 'file',
-                    'zone': 0,
-                    'name': 'file_2',
-                    'size': 0,
-                    'owner': 'admin',
-                    'container_code': reused_container_code,
-                    'container_type': 'project',
-                    'location_uri': 'https://example.com',
-                    'version': '1.0',
-                    'tags': [],
-                    'system_tags': [],
-                    'attribute_template_id': None,
-                    'attributes': {},
-                },
-            ]
-        }
-        response = self.app.put('/v1/items/batch/', params=params, json=payload)
-        assert response.status_code == 200
-        assert loads(response.text)['result'][0]['parent_path'] == 'folder1.folder2.folder3'
-
-    @pytest.mark.dependency(depends=['test_14'])
-    def test_delete_items_by_id_batch_200(self):
-        params = {'ids': [reused_item_ids[1], reused_item_ids[2]]}
-        response = self.app.delete('/v1/items/batch/', params=params)
-        assert response.status_code == 200
-
+        response = app.post('/v1/item/', json=payload)
+        assert response.status_code == 422
+    
     def test_create_name_folder_with_parent_422(self):
         payload = {
-            'parent': '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-            'parent_path': 'folder1.folder2',
+            'parent': str(uuid.uuid4()),
+            'parent_path': None,
             'type': 'name_folder',
             'zone': 0,
-            'name': 'file',
+            'name': 'user',
             'size': 0,
-            'owner': 'admin',
-            'container_code': reused_container_code,
+            'owner': 'user',
+            'container_code': 'test_project',
             'container_type': 'project',
-            'location_uri': 'https://example.com',
-            'version': '1.0',
+            'location_uri': '',
+            'version': '',
+        }
+        response = app.post('/v1/item/', json=payload)
+        assert response.status_code == 422
+
+    def test_update_item_200(self, test_items):
+        params = {'id': test_items['file']}
+        payload = {
+            'name': 'test_file_updated.txt'
+        }
+        response = app.put('/v1/item/', json=payload, params=params)
+        assert response.status_code == 200
+        assert loads(response.text)['result']['name'] == 'test_file_updated.txt'
+    
+    def test_update_items_batch_200(self, test_items):
+        params = {'ids': [test_items['name_folder'], test_items['folder'], test_items['file']]}
+        payload = {'items': [{'owner': 'user_2'}, {'tags': ['update_items_batch']}, {'size': 500}]}
+        response = app.put('/v1/items/batch/', params=params, json=payload)
+        assert response.status_code == 200
+        assert loads(response.text)['result'][0]['owner'] == 'user_2'
+        assert loads(response.text)['result'][1]['extended']['extra']['tags'] == ['update_items_batch']
+        assert loads(response.text)['result'][2]['size'] == 500
+    
+    def test_update_item_wrong_type_422(self, test_items):
+        params = {'id': test_items['file']}
+        payload = {
+            'type': 'invalid'
+        }
+        response = app.put('/v1/item/', json=payload, params=params)
+        assert response.status_code == 422
+    
+    def test_update_item_wrong_container_type_422(self, test_items):
+        params = {'id': test_items['file']}
+        payload = {
+            'container_type': 'invalid'
+        }
+        response = app.put('/v1/item/', json=payload, params=params)
+        assert response.status_code == 422
+
+    def test_trash_item_200(self, test_items):
+        params = {
+            'id': test_items['file'],
+            'archived': True,
+        }
+        response = app.patch('/v1/item/', params=params)
+        assert response.status_code == 200
+        assert loads(response.text)['result']['archived'] == True
+
+    def test_restore_item_200(self, test_items):
+        params = {
+            'id': test_items['file'],
+            'archived': False,
+        }
+        response = app.patch('/v1/item/', params=params)
+        assert response.status_code == 200
+        assert loads(response.text)['result']['archived'] == False
+
+    def test_rename_item_on_conflict_200(self, test_items):
+        params = {
+            'id': test_items['file'],
+            'archived': True,
+        }
+        app.patch('/v1/item/', params=params)
+        item_id = str(uuid.uuid4())
+        self.cleanup_item_ids.append(item_id)
+        payload = {
+            'id': item_id,
+            'parent': test_items['folder'],
+            'parent_path': 'user.test_folder',
+            'type': 'file',
+            'zone': 0,
+            'name': 'test_file.txt',
+            'size': 100,
+            'owner': 'user',
+            'container_code': 'test_project',
+            'container_type': 'project',
+            'location_uri': '',
+            'version': '',
             'tags': [],
             'system_tags': [],
             'attribute_template_id': None,
             'attributes': {},
         }
-        response = self.app.post('/v1/item/', json=payload)
-        assert response.status_code == 422
+        app.post('/v1/item/', json=payload)
+        params = {
+            'id': test_items['file'],
+            'archived': False,
+        }
+        response = app.patch('/v1/item/', params=params)
+        print(response.text)
+        assert response.status_code == 200
+        assert '_' in loads(response.text)['result']['name']
+
+    def test_delete_item_200(self, test_items):
+        params = {'id': test_items['file']}
+        response = app.delete('/v1/item/', params=params)
+        assert response.status_code == 200
+
+    def test_delete_items_by_id_batch_200(self, test_items):
+        params = {'ids': [test_items['file_2'], test_items['file_3']]}
+        response = app.delete('/v1/items/batch/', params=params)
+        assert response.status_code == 200

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -13,8 +13,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from json import loads
 import uuid
+from json import loads
 
 from fastapi.testclient import TestClient
 
@@ -35,7 +35,7 @@ class TestItems:
     def test_get_item_by_id_200(self, test_items):
         response = app.get(f'/v1/item/{test_items["file"]}/')
         assert response.status_code == 200
-    
+
     def test_get_item_by_location_200(self):
         params = {
             'parent_path': 'user.test_folder',
@@ -47,7 +47,7 @@ class TestItems:
         }
         response = app.get('/v1/items/search/', params=params)
         assert response.status_code == 200
-    
+
     def test_get_item_by_location_missing_zone_422(self):
         params = {
             'parent_path': 'user.test_folder',
@@ -58,7 +58,7 @@ class TestItems:
         }
         response = app.get('/v1/item/search/', params=params)
         assert response.status_code == 422
-    
+
     def test_get_items_by_id_batch_200(self, test_items):
         params = {'ids': [test_items['name_folder'], test_items['folder'], test_items['file']]}
         response = app.get('/v1/items/batch/', params=params)
@@ -87,7 +87,7 @@ class TestItems:
         }
         response = app.post('/v1/item/', json=payload)
         assert response.status_code == 200
-    
+
     def test_create_items_batch_200(self):
         item_ids = [str(uuid.uuid4()), str(uuid.uuid4())]
         for id in item_ids:
@@ -134,7 +134,7 @@ class TestItems:
         }
         response = app.post('/v1/items/batch/', json=payload)
         assert response.status_code == 200
-    
+
     def test_create_item_wrong_type_422(self):
         payload = {
             'id': str(uuid.uuid4()),
@@ -156,7 +156,7 @@ class TestItems:
         }
         response = app.post('/v1/item/', json=payload)
         assert response.status_code == 422
-    
+
     def test_create_item_wrong_container_type_422(self):
         payload = {
             'id': str(uuid.uuid4()),
@@ -178,7 +178,7 @@ class TestItems:
         }
         response = app.post('/v1/item/', json=payload)
         assert response.status_code == 422
-    
+
     def test_create_name_folder_with_parent_422(self):
         payload = {
             'parent': str(uuid.uuid4()),
@@ -198,13 +198,11 @@ class TestItems:
 
     def test_update_item_200(self, test_items):
         params = {'id': test_items['file']}
-        payload = {
-            'name': 'test_file_updated.txt'
-        }
+        payload = {'name': 'test_file_updated.txt'}
         response = app.put('/v1/item/', json=payload, params=params)
         assert response.status_code == 200
         assert loads(response.text)['result']['name'] == 'test_file_updated.txt'
-    
+
     def test_update_items_batch_200(self, test_items):
         params = {'ids': [test_items['name_folder'], test_items['folder'], test_items['file']]}
         payload = {'items': [{'owner': 'user_2'}, {'tags': ['update_items_batch']}, {'size': 500}]}
@@ -213,20 +211,16 @@ class TestItems:
         assert loads(response.text)['result'][0]['owner'] == 'user_2'
         assert loads(response.text)['result'][1]['extended']['extra']['tags'] == ['update_items_batch']
         assert loads(response.text)['result'][2]['size'] == 500
-    
+
     def test_update_item_wrong_type_422(self, test_items):
         params = {'id': test_items['file']}
-        payload = {
-            'type': 'invalid'
-        }
+        payload = {'type': 'invalid'}
         response = app.put('/v1/item/', json=payload, params=params)
         assert response.status_code == 422
-    
+
     def test_update_item_wrong_container_type_422(self, test_items):
         params = {'id': test_items['file']}
-        payload = {
-            'container_type': 'invalid'
-        }
+        payload = {'container_type': 'invalid'}
         response = app.put('/v1/item/', json=payload, params=params)
         assert response.status_code == 422
 


### PR DESCRIPTION
## Summary

- Change trash/restore behaviour to act recursively if the specified item is a folder.
- Update all unit tests to remove dependencies between tests.

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-932

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes
- [ ] No

## Test Directions

1. Use the post endpoint to create a series of nested items.
2. Trash and restore the parent. All children should be acted upon along with the parent.
