### PR TITLE
PILOT-861 Add bequeath properties endpoint

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -56,6 +56,7 @@ class Settings(BaseSettings):
 
     MAX_TAGS = 10
     MAX_SYSTEM_TAGS = 10
+    MAX_ATTRIBUTE_LENGTH = 100
 
     def __init__(self):
         super().__init__()

--- a/app/models/models_items.py
+++ b/app/models/models_items.py
@@ -97,7 +97,7 @@ class POSTItem(BaseModel):
     tags: list[str] = []
     system_tags: list[str] = []
     attribute_template_id: Optional[UUID]
-    attributes: dict = {}
+    attributes: Optional[dict] = {}
 
     class Config:
         anystr_strip_whitespace = True
@@ -146,6 +146,9 @@ class POSTItem(BaseModel):
     def attributes_only_on_files(cls, v, values):
         if v and 'type' in values and values['type'] != 'file':
             raise ValueError('Attributes can only be applied to files')
+        for attribute in v.values():
+            if len(attribute) > ConfigClass.MAX_ATTRIBUTE_LENGTH:
+                raise ValueError(f'Attribute exceeds maximum length of {ConfigClass.MAX_ATTRIBUTE_LENGTH} characters: {attribute}')
 
     @validator('attribute_template_id')
     def attribute_template_only_on_files(cls, v, values):

--- a/app/models/models_items.py
+++ b/app/models/models_items.py
@@ -106,13 +106,13 @@ class POSTItem(BaseModel):
     def type_is_valid(cls, v, values):
         if v not in ['file', 'folder', 'name_folder']:
             raise ValueError('type must be one of: file, folder, name_folder')
-        if 'parent' in values and values['parent'] and v == 'name_folder':
+        elif 'parent' in values and values['parent'] and v == 'name_folder':
             raise ValueError('Name folders cannot have a parent')
-        if 'parent_path' in values and values['parent_path'] and v == 'name_folder':
+        elif 'parent_path' in values and values['parent_path'] and v == 'name_folder':
             raise ValueError('Name folders cannot have a parent_path')
-        if 'parent' not in values or not values['parent'] and v != 'name_folder':
+        elif 'parent' not in values or not values['parent'] and v != 'name_folder':
             raise ValueError('Files and folders must have a parent')
-        if 'parent_path' not in values or not values['parent_path'] and v != 'name_folder':
+        elif 'parent_path' not in values or not values['parent_path'] and v != 'name_folder':
             raise ValueError('Files and folders must have a parent_path')
         return v
 
@@ -120,7 +120,7 @@ class POSTItem(BaseModel):
     def container_type_is_valid(cls, v, values):
         if v not in ['project', 'dataset']:
             raise ValueError('container_type must be project or dataset')
-        if 'type' in values and values['type'] == 'name_folder' and v != 'project':
+        elif 'type' in values and values['type'] == 'name_folder' and v != 'project':
             raise ValueError('Name folders are only allowed in projects')
         return v
 
@@ -143,17 +143,19 @@ class POSTItem(BaseModel):
         return v
 
     @validator('attributes')
-    def attributes_only_on_files(cls, v, values):
-        if v and 'type' in values and values['type'] != 'file':
+    def attributes_are_valid(cls, v, values):
+        if 'type' in values and values['type'] != 'file':
             raise ValueError('Attributes can only be applied to files')
         for attribute in v.values():
             if len(attribute) > ConfigClass.MAX_ATTRIBUTE_LENGTH:
                 raise ValueError(f'Attribute exceeds maximum length of {ConfigClass.MAX_ATTRIBUTE_LENGTH} characters: {attribute}')
-
+        return v
+    
     @validator('attribute_template_id')
     def attribute_template_only_on_files(cls, v, values):
-        if v and 'type' in values and values['type'] != 'file':
+        if 'type' in values and values['type'] != 'file':
             raise ValueError('Attribute templates can only be applied to files')
+        return v
 
 
 class POSTItems(BaseModel):

--- a/app/models/models_items.py
+++ b/app/models/models_items.py
@@ -142,6 +142,16 @@ class POSTItem(BaseModel):
             raise ValueError('Folder name cannot contain reserved character: .')
         return v
 
+    @validator('attributes')
+    def attributes_only_on_files(cls, v, values):
+        if v and 'type' in values and values['type'] != 'file':
+            raise ValueError('Attributes can only be applied to files')
+
+    @validator('attribute_template_id')
+    def attribute_template_only_on_files(cls, v, values):
+        if v and 'type' in values and values['type'] != 'file':
+            raise ValueError('Attribute templates can only be applied to files')
+
 
 class POSTItems(BaseModel):
     items: list[POSTItem]
@@ -194,4 +204,13 @@ class DELETEItem(BaseModel):
 
 
 class DELETEItemResponse(APIResponse):
+    pass
+
+
+class PUTItemsBequeathAttributes(BaseModel):
+    attribute_template_id: UUID
+    attributes: dict
+
+
+class PUTItemsBequeathAttributesResponse(GETItemResponse):
     pass

--- a/app/models/models_items.py
+++ b/app/models/models_items.py
@@ -207,10 +207,11 @@ class DELETEItemResponse(APIResponse):
     pass
 
 
-class PUTItemsBequeathAttributes(BaseModel):
-    attribute_template_id: UUID
-    attributes: dict
+class PUTItemsBequeath(BaseModel):
+    attribute_template_id: Optional[UUID]
+    attributes: Optional[dict]
+    system_tags: Optional[list[str]]
 
 
-class PUTItemsBequeathAttributesResponse(GETItemResponse):
+class PUTItemsBequeathResponse(GETItemResponse):
     pass

--- a/app/models/models_items.py
+++ b/app/models/models_items.py
@@ -148,9 +148,11 @@ class POSTItem(BaseModel):
             raise ValueError('Attributes can only be applied to files')
         for attribute in v.values():
             if len(attribute) > ConfigClass.MAX_ATTRIBUTE_LENGTH:
-                raise ValueError(f'Attribute exceeds maximum length of {ConfigClass.MAX_ATTRIBUTE_LENGTH} characters: {attribute}')
+                raise ValueError(
+                    f'Attribute exceeds maximum length of {ConfigClass.MAX_ATTRIBUTE_LENGTH} characters: {attribute}'
+                )
         return v
-    
+
     @validator('attribute_template_id')
     def attribute_template_only_on_files(cls, v, values):
         if 'type' in values and values['type'] != 'file':

--- a/app/models/sql_extended.py
+++ b/app/models/sql_extended.py
@@ -37,8 +37,8 @@ class ExtendedModel(Base):
     __table_args__ = ({'schema': ConfigClass.METADATA_SCHEMA},)
 
     def __init__(self, item_id, extra):
-        self.id = (uuid.uuid4(),)
-        self.item_id = (item_id,)
+        self.id = uuid.uuid4(),
+        self.item_id = item_id,
         self.extra = extra
 
     def to_dict(self):

--- a/app/models/sql_extended.py
+++ b/app/models/sql_extended.py
@@ -37,8 +37,8 @@ class ExtendedModel(Base):
     __table_args__ = ({'schema': ConfigClass.METADATA_SCHEMA},)
 
     def __init__(self, item_id, extra):
-        self.id = uuid.uuid4(),
-        self.item_id = item_id,
+        self.id = uuid.uuid4()
+        self.item_id = item_id
         self.extra = extra
 
     def to_dict(self):

--- a/app/routers/v1/items/api_items.py
+++ b/app/routers/v1/items/api_items.py
@@ -37,14 +37,14 @@ from app.models.models_items import POSTItems
 from app.models.models_items import PUTItem
 from app.models.models_items import PUTItemResponse
 from app.models.models_items import PUTItems
-from app.models.models_items import PUTItemsBequeathAttributes
-from app.models.models_items import PUTItemsBequeathAttributesResponse
+from app.models.models_items import PUTItemsBequeath
+from app.models.models_items import PUTItemsBequeathResponse
 from app.routers.router_exceptions import BadRequestException
 from app.routers.router_exceptions import EntityNotFoundException
 from app.routers.router_utils import set_api_response_error
 
 from .crud import archive_item_by_id
-from .crud import bequeath_attributes
+from .crud import bequeath_to_children
 from .crud import create_item
 from .crud import create_items
 from .crud import delete_item_by_id
@@ -180,14 +180,14 @@ class APIItemsBulk:
         return api_response.json_response()
 
     @router_bulk.put(
-        '/batch/attributes/',
-        response_model=PUTItemsBequeathAttributesResponse,
-        summary='Bequeath attributes to an item\'s children',
+        '/batch/bequeath/',
+        response_model=PUTItemsBequeathResponse,
+        summary='Bequeath properties to a folder\'s children',
     )
-    async def update_items_bequeath_attributes(self, data: PUTItemsBequeathAttributes, id: UUID = Query(None)):
+    async def update_items_bequeath(self, data: PUTItemsBequeath, id: UUID = Query(None)):
         try:
-            api_response = PUTItemsBequeathAttributesResponse()
-            bequeath_attributes(id, data, api_response)
+            api_response = PUTItemsBequeathResponse()
+            bequeath_to_children(id, data, api_response)
         except BadRequestException as e:
             set_api_response_error(api_response, str(e), EAPIResponseCode.bad_request)
         except Exception as e:

--- a/app/routers/v1/items/api_items.py
+++ b/app/routers/v1/items/api_items.py
@@ -37,11 +37,14 @@ from app.models.models_items import POSTItems
 from app.models.models_items import PUTItem
 from app.models.models_items import PUTItemResponse
 from app.models.models_items import PUTItems
+from app.models.models_items import PUTItemsBequeathAttributes
+from app.models.models_items import PUTItemsBequeathAttributesResponse
 from app.routers.router_exceptions import BadRequestException
 from app.routers.router_exceptions import EntityNotFoundException
 from app.routers.router_utils import set_api_response_error
 
 from .crud import archive_item_by_id
+from .crud import bequeath_attributes
 from .crud import create_item
 from .crud import create_items
 from .crud import delete_item_by_id
@@ -89,6 +92,7 @@ class APIItems:
         except BadRequestException as e:
             set_api_response_error(api_response, str(e), EAPIResponseCode.bad_request)
         except Exception as e:
+            print(e)
             _logger.exception(e)
             set_api_response_error(api_response, 'Failed to update item', EAPIResponseCode.internal_error)
         return api_response.json_response()
@@ -174,4 +178,20 @@ class APIItemsBulk:
         except Exception as e:
             _logger.exception(e)
             set_api_response_error(api_response, 'Failed to delete items', EAPIResponseCode.not_found)
+        return api_response.json_response()
+
+    @router_bulk.put(
+        '/batch/attributes/',
+        response_model=PUTItemsBequeathAttributesResponse,
+        summary='Bequeath attributes to an item\'s children',
+    )
+    async def update_items_bequeath_attributes(self, data: PUTItemsBequeathAttributes, id: UUID = Query(None)):
+        try:
+            api_response = PUTItemsBequeathAttributesResponse()
+            bequeath_attributes(id, data, api_response)
+        except BadRequestException as e:
+            set_api_response_error(api_response, str(e), EAPIResponseCode.bad_request)
+        except Exception as e:
+            _logger.exception(e)
+            set_api_response_error(api_response, f'Failed to get item with id {id}', EAPIResponseCode.not_found)
         return api_response.json_response()

--- a/app/routers/v1/items/api_items.py
+++ b/app/routers/v1/items/api_items.py
@@ -92,7 +92,6 @@ class APIItems:
         except BadRequestException as e:
             set_api_response_error(api_response, str(e), EAPIResponseCode.bad_request)
         except Exception as e:
-            print(e)
             _logger.exception(e)
             set_api_response_error(api_response, 'Failed to update item', EAPIResponseCode.internal_error)
         return api_response.json_response()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,8 +75,6 @@ def test_items() -> dict:
                 'version': '',
                 'tags': [],
                 'system_tags': [],
-                'attribute_template_id': None,
-                'attributes': {},
             },
             {
                 'id': props['ids']['file_1'],
@@ -93,8 +91,6 @@ def test_items() -> dict:
                 'version': '',
                 'tags': [],
                 'system_tags': [],
-                'attribute_template_id': None,
-                'attributes': {},
             },
             {
                 'id': props['ids']['file_2'],
@@ -111,8 +107,6 @@ def test_items() -> dict:
                 'version': '',
                 'tags': [],
                 'system_tags': [],
-                'attribute_template_id': None,
-                'attributes': {},
             },
             {
                 'id': props['ids']['file_3'],
@@ -129,8 +123,6 @@ def test_items() -> dict:
                 'version': '',
                 'tags': [],
                 'system_tags': [],
-                'attribute_template_id': None,
-                'attributes': {},
             },
         ],
     }

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -83,8 +83,6 @@ class TestItems:
             'version': '',
             'tags': [],
             'system_tags': [],
-            'attribute_template_id': None,
-            'attributes': {},
         }
         response = app.post('/v1/item/', json=payload)
         assert response.status_code == 200
@@ -110,8 +108,6 @@ class TestItems:
                     'version': '',
                     'tags': [],
                     'system_tags': [],
-                    'attribute_template_id': None,
-                    'attributes': {},
                 },
                 {
                     'id': item_ids[1],
@@ -128,8 +124,6 @@ class TestItems:
                     'version': '',
                     'tags': [],
                     'system_tags': [],
-                    'attribute_template_id': None,
-                    'attributes': {},
                 },
             ]
         }
@@ -152,8 +146,6 @@ class TestItems:
             'version': '',
             'tags': [],
             'system_tags': [],
-            'attribute_template_id': None,
-            'attributes': {},
         }
         response = app.post('/v1/item/', json=payload)
         assert response.status_code == 422
@@ -174,8 +166,6 @@ class TestItems:
             'version': '',
             'tags': [],
             'system_tags': [],
-            'attribute_template_id': None,
-            'attributes': {},
         }
         response = app.post('/v1/item/', json=payload)
         assert response.status_code == 422
@@ -288,8 +278,6 @@ class TestItems:
             'version': '',
             'tags': [],
             'system_tags': [],
-            'attribute_template_id': None,
-            'attributes': {},
         }
         app.post('/v1/item/', json=payload)
         params = {

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -298,3 +298,17 @@ class TestItems:
         params = {'ids': [test_items['ids']['file_2'], test_items['ids']['file_3']]}
         response = app.delete('/v1/items/batch/', params=params)
         assert response.status_code == 200
+
+    def test_bequeath_attributes_200(self, test_items, test_attribute_template):
+        params = {'id': test_items['ids']['folder']}
+        payload = {
+            'attribute_template_id': test_attribute_template,
+            'attributes': {'attribute_1': 'val1'},
+        }
+        response = app.put('/v1/items/batch/attributes/', params=params, json=payload)
+        assert response.status_code == 200
+        assert len(loads(response.text)['result']) == 3
+        assert (
+            loads(response.text)['result'][0]['extended']['extra']['attributes'][test_attribute_template]
+            == payload['attributes']
+        )

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -299,16 +299,18 @@ class TestItems:
         response = app.delete('/v1/items/batch/', params=params)
         assert response.status_code == 200
 
-    def test_bequeath_attributes_200(self, test_items, test_attribute_template):
+    def test_bequeath_to_children_200(self, test_items, test_attribute_template):
         params = {'id': test_items['ids']['folder']}
         payload = {
             'attribute_template_id': test_attribute_template,
             'attributes': {'attribute_1': 'val1'},
+            'system_tags': ['copied-to-core'],
         }
-        response = app.put('/v1/items/batch/attributes/', params=params, json=payload)
+        response = app.put('/v1/items/batch/bequeath/', params=params, json=payload)
         assert response.status_code == 200
         assert len(loads(response.text)['result']) == 3
         assert (
             loads(response.text)['result'][0]['extended']['extra']['attributes'][test_attribute_template]
             == payload['attributes']
         )
+        assert loads(response.text)['result'][0]['extended']['extra']['system_tags'] == payload['system_tags']


### PR DESCRIPTION
## Summary

- Addresses QA feedback on PILOT-861:
	- Add new endpoint `PUT /v1/items/batch/bequeath/` that takes the ID of a folder item and applies attributes and/or system tags data to all of its children.
- Prevent attribute data from being set for any type of item that is not a file.

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-861

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes

## Test Directions

Test the new endpoint to ensure that it works the way that you would expect:
1. Create a folder-file hierarchy.
2. Pass the folder's ID to the new endpoint.
3. Check that the files under the folder have the given properties.
