### PR TITLE
PILOT-932 Fix paths during recursive item archive

### DIFF
--- a/app/routers/v1/items/crud.py
+++ b/app/routers/v1/items/crud.py
@@ -106,7 +106,7 @@ def move_item(item: ItemModel, new_parent_path: str):
     children = get_children_of_item(item, True)
     item.parent_path = Ltree(encode_path_for_ltree(new_parent_path)) if new_parent_path else None
     for child in children:
-        move_item(child[0], f'{new_parent_path}.{decode_label_from_ltree(item.name)}')
+        move_item(child[0], f'{new_parent_path}.{decode_label_from_ltree(item.name)}' if new_parent_path else decode_label_from_ltree(item.name))
 
 
 def attributes_match_template(attributes: dict, template_id: UUID) -> bool:

--- a/app/routers/v1/items/crud.py
+++ b/app/routers/v1/items/crud.py
@@ -310,7 +310,6 @@ def archive_item(item: ItemModel, trash_item: bool, parent: bool):
                 item.name = get_available_file_name(item.container_code, item.zone, item.name, None, True)
                 item.parent = None
             item.restore_path = item.parent_path
-            item.parent_path = None
         else:
             if parent:
                 restore_destination_id = get_restore_destination_id(item.container_code, item.zone, item.restore_path)
@@ -343,6 +342,8 @@ def archive_item_by_id(params: PATCHItem, api_response: APIResponse):
         for child in children_result:
             archive_item(child[0], params.archived, False)
             all_items.append(child)
+        if params.archived:
+            move_item(root_item_result[0], None)
     except BadRequestException:
         raise
     db.session.commit()

--- a/app/routers/v1/items/crud.py
+++ b/app/routers/v1/items/crud.py
@@ -106,7 +106,12 @@ def move_item(item: ItemModel, new_parent_path: str):
     children = get_children_of_item(item, True)
     item.parent_path = Ltree(encode_path_for_ltree(new_parent_path)) if new_parent_path else None
     for child in children:
-        move_item(child[0], f'{new_parent_path}.{decode_label_from_ltree(item.name)}' if new_parent_path else decode_label_from_ltree(item.name))
+        move_item(
+            child[0],
+            f'{new_parent_path}.{decode_label_from_ltree(item.name)}'
+            if new_parent_path
+            else decode_label_from_ltree(item.name),
+        )
 
 
 def attributes_match_template(attributes: dict, template_id: UUID) -> bool:

--- a/app/routers/v1/items/utils.py
+++ b/app/routers/v1/items/utils.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2022 Indoc Research
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+def combine_item_tables(item_result: tuple) -> dict:
+    item_data = item_result[0].to_dict()
+    storage_data = item_result[1].to_dict()
+    storage_data.pop('item_id')
+    extended_data = item_result[2].to_dict()
+    extended_data.pop('item_id')
+    item_data['storage'] = storage_data
+    item_data['extended'] = extended_data
+    return item_data

--- a/app/routers/v1/items/utils.py
+++ b/app/routers/v1/items/utils.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+
 def combine_item_tables(item_result: tuple) -> dict:
     item_data = item_result[0].to_dict()
     storage_data = item_result[1].to_dict()


### PR DESCRIPTION
## Summary

- Addresses QA feedback from https://github.com/PilotDataPlatform/metadata/pull/11:
	- Children's `parent_path` adapts correctly to the trash environment when nested items are trashed.
- When updating a folder's `parent_path` or `name`, its children will update appropriately.

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-932

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Are there any new or updated tests to validate the changes?

- [x] No

## Test Directions

Recursive archive:
1. Create a series of nested items.
2. Archive the parent folder.
3. Check that the paths are as you would expect.

Recursive update:
1. Create a series of nested items.
2. Update the parent folder's `parent_path` or `name`.
3. Check that the children update appropriately.