### PR TITLE
PILOT-931 Add sorting in search

### DIFF
--- a/app/models/base_models.py
+++ b/app/models/base_models.py
@@ -54,4 +54,4 @@ class PaginationRequest(BaseModel):
     page: int = 0
     page_size: int = 25
     order: str = 'asc'
-    sorting: str = 'createTime'
+    sorting: str = 'created_time'

--- a/app/models/models_items.py
+++ b/app/models/models_items.py
@@ -23,6 +23,7 @@ from pydantic import validator
 from app.config import ConfigClass
 
 from .base_models import APIResponse
+from .base_models import PaginationRequest
 
 
 class GETItem(BaseModel):
@@ -34,15 +35,13 @@ class GETItemsByIDs(BaseModel):
     page: int = 0
 
 
-class GETItemsByLocation(BaseModel):
+class GETItemsByLocation(PaginationRequest):
     container_code: str
     zone: int
     recursive: bool
     archived: bool = False
     parent_path: Optional[str]
     name: Optional[str]
-    page_size: int = 10
-    page: int = 0
 
     class Config:
         anystr_strip_whitespace = True

--- a/app/models/sql_items.py
+++ b/app/models/sql_items.py
@@ -87,7 +87,7 @@ class ItemModel(Base):
             'archived': self.archived,
             'type': self.type,
             'zone': self.zone,
-            'name': decode_label_from_ltree(self.name),
+            'name': self.name,
             'size': self.size,
             'owner': self.owner,
             'container_code': self.container_code,

--- a/app/models/sql_items.py
+++ b/app/models/sql_items.py
@@ -40,7 +40,7 @@ class ItemModel(Base):
     parent_path = Column(LtreeType())
     restore_path = Column(LtreeType())
     archived = Column(Boolean(), nullable=False)
-    type = Column(Enum('file', 'folder', 'name_folder', name='type_enum', create_type=False), nullable=False)
+    type = Column(Enum('name_folder', 'folder', 'file', name='type_enum', create_type=False), nullable=False)
     zone = Column(Integer(), nullable=False)
     name = Column(String(), nullable=False)
     size = Column(Integer())

--- a/app/routers/v1/items/crud.py
+++ b/app/routers/v1/items/crud.py
@@ -170,6 +170,9 @@ def get_items_by_ids(params: GETItemsByIDs, ids: list[UUID], api_response: APIRe
 
 
 def get_items_by_location(params: GETItemsByLocation, api_response: APIResponse):
+    custom_sort = getattr(ItemModel, params.sorting).asc()
+    if params.order == 'desc':
+        custom_sort = getattr(ItemModel, params.sorting).desc()
     item_query = (
         db.session.query(ItemModel, StorageModel, ExtendedModel)
         .join(StorageModel, ExtendedModel)
@@ -178,6 +181,7 @@ def get_items_by_location(params: GETItemsByLocation, api_response: APIResponse)
             ItemModel.zone == params.zone,
             ItemModel.archived == params.archived,
         )
+        .order_by(ItemModel.type, custom_sort)
     )
     if params.name:
         item_query = item_query.filter(ItemModel.name == encode_label_for_ltree(params.name))

--- a/app/routers/v1/items/crud.py
+++ b/app/routers/v1/items/crud.py
@@ -51,7 +51,7 @@ from app.routers.v1.items.utils import combine_item_tables
 def get_available_file_name(
     container_code: UUID,
     zone: int,
-    encoded_item_name: str,
+    item_name: str,
     encoded_item_path: Ltree,
     archived: bool,
 ) -> str:
@@ -60,31 +60,29 @@ def get_available_file_name(
         .filter_by(
             container_code=container_code,
             zone=zone,
-            name=encoded_item_name,
+            name=item_name,
             parent_path=encoded_item_path,
             archived=archived,
         )
         .first()
     )
     if not item:
-        return encoded_item_name
-    decoded_item_name = decode_label_from_ltree(encoded_item_name)
-    decoded_item_extension = ''
-    if '.' in decoded_item_name:
-        item_name_split = decoded_item_name.split('.', 1)
-        decoded_item_name = item_name_split[0]
-        decoded_item_extension = '.' + item_name_split[1]
+        return item_name
+    item_extension = ''
+    if '.' in item_name:
+        item_name_split = item_name.split('.', 1)
+        item_name = item_name_split[0]
+        item_extension = '.' + item_name_split[1]
     timestamp = round(time.time())
-    decoded_item_name_new = f'{decoded_item_name}_{timestamp}{decoded_item_extension}'
-    encoded_item_name_new = encode_label_for_ltree(decoded_item_name_new)
-    return encoded_item_name_new
+    item_name_new = f'{item_name}_{timestamp}{item_extension}'
+    return item_name_new
 
 
 def get_children_of_item(root_item: ItemModel, first_children_only: bool = False) -> list[tuple]:
     search_path = (
-        f'{root_item.restore_path}.{root_item.name}'
+        f'{root_item.restore_path}.{encode_label_for_ltree(root_item.name)}'
         if root_item.archived
-        else f'{root_item.parent_path}.{root_item.name}'
+        else f'{root_item.parent_path}.{encode_label_for_ltree(root_item.name)}'
     )
     if not first_children_only:
         search_path += '.*'
@@ -109,16 +107,16 @@ def move_item(item: ItemModel, new_parent_path: str):
     for child in children:
         move_item(
             child[0],
-            f'{new_parent_path}.{decode_label_from_ltree(item.name)}'
+            f'{new_parent_path}.{item.name}'
             if new_parent_path
-            else decode_label_from_ltree(item.name),
+            else item.name,
         )
 
 
 def rename_item(item: ItemModel, old_name: str, new_name: str, root_item: bool = True):
     children = get_children_of_item(item, True)
     if root_item:
-        item.name = encode_label_for_ltree(new_name)
+        item.name = new_name
     else:
         decoded_parent_path = decode_path_from_ltree(str(item.parent_path))
         new_parent_path = re.sub(old_name, new_name, decoded_parent_path, 1)
@@ -184,7 +182,7 @@ def get_items_by_location(params: GETItemsByLocation, api_response: APIResponse)
         .order_by(ItemModel.type, custom_sort)
     )
     if params.name:
-        item_query = item_query.filter(ItemModel.name == encode_label_for_ltree(params.name))
+        item_query = item_query.filter(ItemModel.name.like(params.name))
     if params.parent_path:
         search_path = encode_path_for_ltree(params.parent_path)
         if params.recursive:
@@ -203,7 +201,6 @@ def get_items_by_location(params: GETItemsByLocation, api_response: APIResponse)
 def create_item(data: POSTItem) -> dict:
     if not attributes_match_template(data.attributes, data.attribute_template_id):
         raise BadRequestException('Attributes do not match attribute template')
-    encoded_item_name = encode_label_for_ltree(data.name)
     item_model_data = {
         'id': data.id if data.id else uuid.uuid4(),
         'parent': data.parent if data.parent else None,
@@ -211,7 +208,7 @@ def create_item(data: POSTItem) -> dict:
         'archived': False,
         'type': data.type,
         'zone': data.zone,
-        'name': encoded_item_name,
+        'name': data.name,
         'size': data.size,
         'owner': data.owner,
         'container_code': data.container_code,
@@ -260,7 +257,7 @@ def update_item(item_id: UUID, data: PUTItem) -> dict:
     if data.zone:
         item.zone = data.zone
     if data.name:
-        rename_item(item, decode_label_from_ltree(item.name), data.name)
+        rename_item(item, item.name, data.name)
     if data.size:
         item.size = data.size
     if data.owner:
@@ -314,7 +311,7 @@ def get_restore_destination_id(container_code: str, zone: int, restore_path: Ltr
         ItemModel.container_code == container_code,
         ItemModel.zone == zone,
         ItemModel.archived == False,
-        ItemModel.name == encode_label_for_ltree(destination_name),
+        ItemModel.name == destination_name,
     )
     if destination_path:
         destination_query = destination_query.filter(

--- a/migrations/versions/212e0e60c178_add_items_table.py
+++ b/migrations/versions/212e0e60c178_add_items_table.py
@@ -25,7 +25,7 @@ def upgrade():
         sa.Column('parent_path', LtreeType()),
         sa.Column('restore_path', LtreeType()),
         sa.Column('archived', sa.Boolean(), nullable=False),
-        sa.Column('type', pg.ENUM('file', 'folder', 'name_folder', name='type_enum', create_type=True), nullable=False),
+        sa.Column('type', pg.ENUM('name_folder', 'folder', 'file', name='type_enum', create_type=True), nullable=False),
         sa.Column('zone', sa.Integer(), nullable=False),
         sa.Column('name', sa.String(), nullable=False),
         sa.Column('size', sa.Integer()),


### PR DESCRIPTION
## Summary

- Search endpoint now sorts items before returning.
	- Default by item `type` (ascending order: `name_folder > folder > file`).
	- Optionally by any other item property using `sorting` and `order` parameters.
- Allows searching by partial name using `%` as a wildcard (e.g. `%file%` for a name containing `file`).
	- This required not encoding `name` in the database anymore. It will still be encoded when included in a path.

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-931

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] No

## Test Directions

1. Create some items and try searching by various parameters.
2. Try searching by partial name with `%` wildcard.
