### PR TITLE
PILOT-1025 Add type, container_type to items search

### DIFF
--- a/app/models/models_items.py
+++ b/app/models/models_items.py
@@ -43,6 +43,7 @@ class GETItemsByLocation(PaginationRequest):
     parent_path: Optional[str]
     name: Optional[str]
     owner: Optional[str]
+    type: Optional[str]
     container_type: Optional[str]
 
     class Config:

--- a/app/models/models_items.py
+++ b/app/models/models_items.py
@@ -43,6 +43,7 @@ class GETItemsByLocation(PaginationRequest):
     parent_path: Optional[str]
     name: Optional[str]
     owner: Optional[str]
+    container_type: Optional[str]
 
     class Config:
         anystr_strip_whitespace = True

--- a/app/models/sql_items.py
+++ b/app/models/sql_items.py
@@ -26,7 +26,6 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy_utils import LtreeType
 
-from app.app_utils import decode_label_from_ltree
 from app.app_utils import decode_path_from_ltree
 from app.config import ConfigClass
 

--- a/app/routers/router_exceptions.py
+++ b/app/routers/router_exceptions.py
@@ -18,5 +18,9 @@ class BadRequestException(Exception):
     pass
 
 
+class DuplicateRecordException(Exception):
+    pass
+
+
 class EntityNotFoundException(Exception):
     pass

--- a/app/routers/router_utils.py
+++ b/app/routers/router_utils.py
@@ -37,6 +37,8 @@ def paginate(params: BaseModel, api_response: APIResponse, query: Base, expand_f
     api_response.num_of_pages = int(int(total) / int(params.page_size)) + 1
     api_response.total = total
     api_response.result = results
+    if api_response.total == 0:
+        set_api_response_error(api_response, 'No results found', EAPIResponseCode.not_found)
 
 
 def set_api_response_error(api_response: APIResponse, message: str, code: EAPIResponseCode):

--- a/app/routers/v1/items/api_items.py
+++ b/app/routers/v1/items/api_items.py
@@ -40,6 +40,7 @@ from app.models.models_items import PUTItems
 from app.models.models_items import PUTItemsBequeath
 from app.models.models_items import PUTItemsBequeathResponse
 from app.routers.router_exceptions import BadRequestException
+from app.routers.router_exceptions import DuplicateRecordException
 from app.routers.router_exceptions import EntityNotFoundException
 from app.routers.router_utils import set_api_response_error
 
@@ -79,6 +80,8 @@ class APIItems:
             api_response.result = create_item(data)
         except BadRequestException as e:
             set_api_response_error(api_response, str(e), EAPIResponseCode.bad_request)
+        except DuplicateRecordException:
+            set_api_response_error(api_response, 'Item conflict in database', EAPIResponseCode.conflict)
         except Exception as e:
             _logger.exception(e)
             set_api_response_error(api_response, 'Failed to create item', EAPIResponseCode.internal_error)

--- a/app/routers/v1/items/crud.py
+++ b/app/routers/v1/items/crud.py
@@ -183,6 +183,8 @@ def get_items_by_ids(params: GETItemsByIDs, ids: list[UUID], api_response: APIRe
 
 
 def get_items_by_location(params: GETItemsByLocation, api_response: APIResponse):
+    if params.type and params.type not in ['name_folder', 'folder', 'file']:
+        raise BadRequestException(f'Invalid type {params.type}')
     if params.container_type and params.container_type not in ['project', 'dataset']:
         raise BadRequestException(f'Invalid container_type {params.container_type}')
     try:
@@ -205,6 +207,8 @@ def get_items_by_location(params: GETItemsByLocation, api_response: APIResponse)
         item_query = item_query.filter(ItemModel.name.like(params.name))
     if params.owner:
         item_query = item_query.filter(ItemModel.owner.like(params.owner))
+    if params.type:
+        item_query = item_query.filter(ItemModel.type == params.type)
     if params.container_type:
         item_query = item_query.filter(ItemModel.container_type == params.container_type)
     if params.parent_path:

--- a/app/routers/v1/items/crud.py
+++ b/app/routers/v1/items/crud.py
@@ -183,6 +183,8 @@ def get_items_by_ids(params: GETItemsByIDs, ids: list[UUID], api_response: APIRe
 
 
 def get_items_by_location(params: GETItemsByLocation, api_response: APIResponse):
+    if params.container_type and params.container_type not in ['project', 'dataset']:
+        raise BadRequestException(f'Invalid container_type {params.container_type}')
     try:
         custom_sort = getattr(ItemModel, params.sorting).asc()
         if params.order == 'desc':
@@ -203,6 +205,8 @@ def get_items_by_location(params: GETItemsByLocation, api_response: APIResponse)
         item_query = item_query.filter(ItemModel.name.like(params.name))
     if params.owner:
         item_query = item_query.filter(ItemModel.owner.like(params.owner))
+    if params.container_type:
+        item_query = item_query.filter(ItemModel.container_type == params.container_type)
     if params.parent_path:
         search_path = encode_path_for_ltree(params.parent_path)
         if params.recursive:

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -37,24 +37,24 @@ class TestItems:
         response = app.get(f'/v1/item/{test_items["ids"]["file_1"]}/')
         assert response.status_code == 200
 
-    def test_get_item_by_location_200(self):
+    def test_get_item_by_location_200(self, test_items):
         params = {
             'parent_path': 'user.test_folder',
-            'name': 'test_file.txt',
+            'name': 'test_file_1.txt',
             'archived': False,
             'zone': 0,
-            'container_code': 'test_project',
+            'container_code': test_items['container_code'],
             'recursive': False,
         }
         response = app.get('/v1/items/search/', params=params)
         assert response.status_code == 200
 
-    def test_get_item_by_location_missing_zone_422(self):
+    def test_get_item_by_location_missing_zone_422(self, test_items):
         params = {
             'parent_path': 'user.test_folder',
-            'name': 'test_file.txt',
+            'name': 'test_file_1.txt',
             'archived': False,
-            'container_code': 'test_project',
+            'container_code': test_items['container_code'],
             'recursive': False,
         }
         response = app.get('/v1/item/search/', params=params)
@@ -222,7 +222,7 @@ class TestItems:
         }
         response = app.patch('/v1/item/', params=params)
         assert response.status_code == 200
-        assert loads(response.text)['result'][0]['archived'] == True
+        assert loads(response.text)['result'][0]['archived']
 
     def test_restore_item_200(self, test_items):
         params = {
@@ -231,7 +231,7 @@ class TestItems:
         }
         response = app.patch('/v1/item/', params=params)
         assert response.status_code == 200
-        assert loads(response.text)['result'][0]['archived'] == False
+        assert not loads(response.text)['result'][0]['archived']
 
     def test_trash_folder_with_children_200(self, test_items):
         params = {
@@ -242,7 +242,7 @@ class TestItems:
         assert response.status_code == 200
         assert len(loads(response.text)['result']) == 4
         for i in range(4):
-            assert loads(response.text)['result'][i]['archived'] == True
+            assert loads(response.text)['result'][i]['archived']
 
     def test_restore_folder_with_children_200(self, test_items):
         params = {
@@ -253,7 +253,7 @@ class TestItems:
         assert response.status_code == 200
         assert len(loads(response.text)['result']) == 4
         for i in range(4):
-            assert loads(response.text)['result'][i]['archived'] == False
+            assert not loads(response.text)['result'][i]['archived']
 
     def test_rename_item_on_conflict_200(self, test_items):
         params = {


### PR DESCRIPTION
## Summary

- Add `type` and `container_type` as optional parameters to the items search endpoint.
- Improve HTTP responses:
	- Create items endpoint now returns 409 when attempting to create a conflicting or duplicate item.
	- Any response that contains zero records now returns 404.

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-1025

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes

## Test Directions

Try out the new parameters in the search endpoint.
