### PR TITLE
Updates validator for item post, adds tests

### DIFF
--- a/app/models/models_items.py
+++ b/app/models/models_items.py
@@ -87,13 +87,13 @@ class POSTItem(BaseModel):
     id: Optional[UUID]
     parent: Optional[UUID] = Field(example='3fa85f64-5717-4562-b3fc-2c963f66afa6')
     parent_path: Optional[str] = Field(example='path.to.file')
+    container_code: str
+    container_type: str = 'project'
     type: str = 'file'
     zone: int = 0
     name: str = Field(example='file_name.txt')
     size: Optional[int]
     owner: str
-    container_code: str
-    container_type: str = 'project'
     location_uri: Optional[str]
     version: Optional[str]
     tags: list[str] = []
@@ -112,10 +112,10 @@ class POSTItem(BaseModel):
             raise ValueError('Name folders cannot have a parent')
         elif 'parent_path' in values and values['parent_path'] and v == 'name_folder':
             raise ValueError('Name folders cannot have a parent_path')
-        elif 'parent' not in values or not values['parent'] and v != 'name_folder':
-            raise ValueError('Files and folders must have a parent')
-        elif 'parent_path' not in values or not values['parent_path'] and v != 'name_folder':
-            raise ValueError('Files and folders must have a parent_path')
+        elif 'parent' not in values or not values['parent'] and v != 'name_folder' and values['container_type'] == 'project':
+            raise ValueError('Files and folders must have a parent_path if not part of a datase')
+        elif 'parent_path' not in values or not values['parent_path'] and v != 'name_folder' and values['container_type'] == 'project':
+            raise ValueError('Files and folders must have a parent_path if not part of a dataset')
         return v
 
     @validator('container_type')

--- a/app/models/models_items.py
+++ b/app/models/models_items.py
@@ -113,7 +113,7 @@ class POSTItem(BaseModel):
         elif 'parent_path' in values and values['parent_path'] and v == 'name_folder':
             raise ValueError('Name folders cannot have a parent_path')
         elif 'parent' not in values or not values['parent'] and v != 'name_folder' and values['container_type'] == 'project':
-            raise ValueError('Files and folders must have a parent_path if not part of a datase')
+            raise ValueError('Files and folders must have a parent if not part of a dataset')
         elif 'parent_path' not in values or not values['parent_path'] and v != 'name_folder' and values['container_type'] == 'project':
             raise ValueError('Files and folders must have a parent_path if not part of a dataset')
         return v

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -187,6 +187,74 @@ class TestItems:
         response = app.post('/v1/item/', json=payload)
         assert response.status_code == 422
 
+    def test_file_empty_parent_project_422(self):
+        item_id = str(uuid.uuid4())
+        self.cleanup_item_ids.append(item_id)
+        payload = {
+            'id': item_id,
+            'parent': None,
+            'parent_path': '',
+            'type': 'file',
+            'zone': 0,
+            'name': 'test_file_no_parent.txt',
+            'size': 0,
+            'owner': 'admin',
+            'container_code': 'create_item_200',
+            'container_type': 'project',
+            'location_uri': '',
+            'version': '',
+            'tags': [],
+            'system_tags': [],
+        }
+        response = app.post('/v1/item/', json=payload)
+        assert response.status_code == 422
+
+    def test_file_empty_parent_dataset_200(self):
+        item_id = str(uuid.uuid4())
+        self.cleanup_item_ids.append(item_id)
+        payload = {
+            'id': item_id,
+            'parent': None,
+            'parent_path': '',
+            'type': 'file',
+            'zone': 0,
+            'name': 'test_file_no_parent.txt',
+            'size': 0,
+            'owner': 'admin',
+            'container_code': 'dataset_empty_parent_200',
+            'container_type': 'dataset',
+            'location_uri': '',
+            'version': '',
+            'tags': [],
+            'system_tags': [],
+        }
+        response = app.post('/v1/item/', json=payload)
+        print(response.content)
+        assert response.status_code == 200
+
+    def test_folder_empty_parent_dataset_200(self):
+        item_id = str(uuid.uuid4())
+        self.cleanup_item_ids.append(item_id)
+        payload = {
+            'id': item_id,
+            'parent': None,
+            'parent_path': '',
+            'type': 'folder',
+            'zone': 0,
+            'name': 'test_folder_no_parent',
+            'size': 0,
+            'owner': 'admin',
+            'container_code': 'dataset_empty_parent_200',
+            'container_type': 'dataset',
+            'location_uri': '',
+            'version': '',
+            'tags': [],
+            'system_tags': [],
+        }
+        response = app.post('/v1/item/', json=payload)
+        print(response.content)
+        assert response.status_code == 200
+
     def test_update_item_200(self, test_items):
         params = {'id': test_items['ids']['file_1']}
         payload = {'name': 'test_file_updated.txt'}


### PR DESCRIPTION
## Summary

Updates validator for `PostItem` so that parent paths need not exist for files and folders in datasets. 

Reorders the fields of the `PostItem` so that pydantic has access to the `container_type` field inside of the `type` validator.  

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-1101

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes

## Test Directions

Run unit tests
