### PR TITLE
PILOT-1118: Fix db key removal when updating item

### DIFF
--- a/app/routers/v1/items/crud.py
+++ b/app/routers/v1/items/crud.py
@@ -302,7 +302,7 @@ def update_item(item_id: UUID, data: PUTItem) -> dict:
     if data.version:
         storage.version = data.version
     extended = db.session.query(ExtendedModel).filter_by(item_id=item_id).first()
-    extra = {}
+    extra = dict(extended.extra)
     if data.tags:
         extra['tags'] = data.tags
     if data.system_tags:
@@ -311,7 +311,7 @@ def update_item(item_id: UUID, data: PUTItem) -> dict:
         if not attributes_match_template(data.attributes, data.attribute_template_id):
             raise BadRequestException('Attributes do not match attribute template')
         extra['attributes'] = {str(data.attribute_template_id): data.attributes} if data.attributes else {}
-    if extra:
+    if any(extra.values()):
         extended.extra = extra
     db.session.commit()
     db.session.refresh(item)


### PR DESCRIPTION
## Summary

- Fix issue that occurred when updating an item, if there are no tags or system_tags attached to the item already, the tags and system_tags keys were removed in the database table.

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-1118

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [X] No

## Test Directions

(Additional instructions for how to run tests or validate functionality if not covered by unit tests)
