### PR TITLE
PILOT-1168: Add optional name parameter to query template

### DIFF
--- a/app/models/models_attribute_templates.py
+++ b/app/models/models_attribute_templates.py
@@ -30,6 +30,7 @@ class GETTemplate(BaseModel):
 
 class GETTemplates(BaseModel):
     project_code: str
+    name: Optional[str]
     page_size: int = 10
     page: int = 0
 

--- a/app/routers/v1/attribute_templates/crud.py
+++ b/app/routers/v1/attribute_templates/crud.py
@@ -37,6 +37,8 @@ def get_template_by_id(params: GETTemplate, api_response: APIResponse):
 
 def get_templates_by_project_code(params: GETTemplates, api_response: APIResponse):
     template_query = db.session.query(AttributeTemplateModel).filter_by(project_code=params.project_code)
+    if params.name:
+        template_query = template_query.filter_by(name=params.name)
     paginate(params, api_response, template_query, None)
 
 

--- a/tests/test_attribute_templates.py
+++ b/tests/test_attribute_templates.py
@@ -32,6 +32,21 @@ class TestAttributeTemplates:
         response = app.get('/v1/template/', params=params)
         assert response.status_code == 200
 
+    def test_get_attribute_template_by_project_code_and_name_200(self, test_attribute_template):
+        params = {'project_code': 'test_project', 'name': 'test_template'}
+        response = app.get('/v1/template/', params=params)
+        res = response.json()['result'][0]
+        assert response.status_code == 200
+        assert res['name'] == 'test_template'
+        assert res['project_code'] == 'test_project'
+
+    def test_get_attribute_template_by_project_code_and_invalid_name_200(self, test_attribute_template):
+        params = {'project_code': 'test_project', 'name': 'invalid_name'}
+        response = app.get('/v1/template/', params=params)
+        res = response.json()['result']
+        assert response.status_code == 200
+        assert res == []
+
     def test_create_attribute_template_200(self):
         payload = {
             'name': 'template_1',


### PR DESCRIPTION
## Summary

- Added functionality to query template by project_code and **optional** template name parameter: `GET /v1/template/`
- Added unit tests to account for optional name parameter

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-1168

## Type of Change
- [X] New feature (non-breaking change which adds functionality)

## Testing

Are there any new or updated tests to validate the changes?

- [X] Yes
- [ ] No

## Test Directions

(Additional instructions for how to run tests or validate functionality if not covered by unit tests)
