### PR TITLE
PILOT-1174 Fix attributes validator

### DIFF
--- a/app/models/models_items.py
+++ b/app/models/models_items.py
@@ -146,7 +146,7 @@ class POSTItem(BaseModel):
 
     @validator('attributes')
     def attributes_are_valid(cls, v, values):
-        if 'type' in values and values['type'] != 'file':
+        if 'type' in values and values['type'] and values['type'] != 'file':
             raise ValueError('Attributes can only be applied to files')
         for attribute in v.values():
             if len(attribute) > ConfigClass.MAX_ATTRIBUTE_LENGTH:
@@ -157,7 +157,7 @@ class POSTItem(BaseModel):
 
     @validator('attribute_template_id')
     def attribute_template_only_on_files(cls, v, values):
-        if 'type' in values and values['type'] != 'file':
+        if 'type' in values and values['type'] and values['type'] != 'file':
             raise ValueError('Attribute templates can only be applied to files')
         return v
 


### PR DESCRIPTION
## Summary

- Fixes a bug where a payload that includes `attributes` but does not include `type` would always fail the attributes validation, making it impossible to add attributes to an existing item.

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-1174

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [x] No

## Test Directions

Create an item without attributes and update its attributes after. Ensure that the validator doesn't prevent the action.
