### PR TITLE
PILOT-1324 Fix bug limiting item size

### DIFF
--- a/app/models/sql_items.py
+++ b/app/models/sql_items.py
@@ -15,6 +15,7 @@
 
 from datetime import datetime
 
+from sqlalchemy import BIGINT
 from sqlalchemy import Boolean
 from sqlalchemy import Column
 from sqlalchemy import DateTime
@@ -42,7 +43,7 @@ class ItemModel(Base):
     type = Column(Enum('name_folder', 'folder', 'file', name='type_enum', create_type=False), nullable=False)
     zone = Column(Integer(), nullable=False)
     name = Column(String(), nullable=False)
-    size = Column(Integer())
+    size = Column(BIGINT())
     owner = Column(String())
     container_code = Column(String(), nullable=False)
     container_type = Column(Enum('project', 'dataset', name='container_enum', create_type=False), nullable=False)

--- a/migrations/versions/644ba6b47222_change_items_size_to_bigint.py
+++ b/migrations/versions/644ba6b47222_change_items_size_to_bigint.py
@@ -1,0 +1,26 @@
+"""Change items size to bigint
+
+Revision ID: 644ba6b47222
+Revises: e9ee5505b100
+Create Date: 2022-07-20 00:07:29.948685
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+from app.config import ConfigClass
+
+
+# revision identifiers, used by Alembic.
+revision = '644ba6b47222'
+down_revision = 'e9ee5505b100'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('items', 'size', existing_type=sa.Integer(), type_=sa.BIGINT(), schema=ConfigClass.METADATA_SCHEMA)
+
+
+def downgrade():
+    op.alter_column('items', 'size', existing_type=sa.BIGINT(), type_=sa.Integer(), schema=ConfigClass.METADATA_SCHEMA)


### PR DESCRIPTION
## Summary

- Change `items` `size` column to `bigint` to accommodate a 64-bit integer.
	- As we are measuring item sizes in bytes, `integer` limited the maximum size to just over 2 gigabytes. This change extends the maximum size way beyond anything we'll ever need.

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-1324

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Are there any new or updated tests to validate the changes?

- [x] No

## Test Directions

N/A
